### PR TITLE
編集画面でサーバーにタスクのステータス要素を追加

### DIFF
--- a/ToDoAppEx/EditViewController.swift
+++ b/ToDoAppEx/EditViewController.swift
@@ -60,7 +60,8 @@ class EditViewController: UIViewController {
                 "category": toDo.category,
                 "startdate": toDo.startdate,
                 "enddate": toDo.enddate,
-                "image": toDo.image
+                "image": toDo.image,
+                "status": toDo.status
             ],
             completion: self.goToNext(data:)
         )

--- a/ToDoAppEx/Model/TodoItem.swift
+++ b/ToDoAppEx/Model/TodoItem.swift
@@ -16,8 +16,8 @@ class TodoItem: Object {
     @objc dynamic var category = ""
     @objc dynamic var startdate = ""
     @objc dynamic var enddate = ""
+    @objc dynamic var status = false
     override static func primaryKey() -> String? {
         return "itemid"
     }
-
 }


### PR DESCRIPTION
## 変更点
TodoItemにBool型のstatusを追加

## どうやって使うか
タスクの状態が変わった場合にtrueを代入する

## なぜ変更/追加したか
タスクの状態を管理する変数が必要なため

## スクショ(UI変更がある場合)

## 備考
