### PR TITLE
shareボタン、searchボタンを隠す

### DIFF
--- a/ToDoAppEx/Base.lproj/Main.storyboard
+++ b/ToDoAppEx/Base.lproj/Main.storyboard
@@ -180,13 +180,10 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Share" id="neR-o8-Yq1">
-                        <barButtonItem key="rightBarButtonItem" title="Item" image="magnifyingglass" catalog="system" id="NjH-zP-6AQ">
-                            <connections>
-                                <segue destination="CHX-AS-gQP" kind="show" id="FvJ-l6-p3f"/>
-                            </connections>
-                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="Item" image="magnifyingglass" catalog="system" id="NjH-zP-6AQ"/>
                     </navigationItem>
                     <connections>
+                        <outlet property="searchButton" destination="NjH-zP-6AQ" id="0he-6o-XgG"/>
                         <outlet property="tableView" destination="wAR-gc-HAg" id="Npu-CI-73J"/>
                     </connections>
                 </viewController>
@@ -377,16 +374,15 @@
                         <color key="backgroundColor" systemColor="systemTealColor"/>
                     </view>
                     <navigationItem key="navigationItem" title="Search" id="S8T-II-nY2">
-                        <barButtonItem key="rightBarButtonItem" title="Item" image="cloud" catalog="system" id="sEz-ds-nV0">
-                            <connections>
-                                <segue destination="4a7-WS-qqK" kind="show" id="meS-CU-nRu"/>
-                            </connections>
-                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="Item" image="cloud" catalog="system" id="sEz-ds-nV0"/>
                     </navigationItem>
+                    <connections>
+                        <outlet property="shareButton" destination="sEz-ds-nV0" id="Akl-kI-1wb"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CZE-Mh-WBF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2025" y="419"/>
+            <point key="canvasLocation" x="1849" y="443"/>
         </scene>
         <!--Login View Controller-->
         <scene sceneID="KRv-Kd-NAM">

--- a/ToDoAppEx/ViewController/SearchViewController.swift
+++ b/ToDoAppEx/ViewController/SearchViewController.swift
@@ -9,8 +9,10 @@ import UIKit
 
 class SearchViewController: UIViewController {
 
+    @IBOutlet weak var shareButton: UIBarButtonItem!
     override func viewDidLoad() {
         super.viewDidLoad()
+        shareButton.tintColor = UIColor.clear
     }
 
 //    func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {

--- a/ToDoAppEx/ViewController/ShareViewController.swift
+++ b/ToDoAppEx/ViewController/ShareViewController.swift
@@ -10,13 +10,14 @@ import RealmSwift
 
 class ShareViewController: UIViewController {
 
+    @IBOutlet weak var searchButton: UIBarButtonItem!
 
     @IBOutlet weak var tableView: UITableView!
 
     private var shareAccounts: [String] = []
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        searchButton.tintColor = UIColor.clear
         getShareAccounts(data: nil)
         tableView.delegate = self
         tableView.dataSource = self


### PR DESCRIPTION
## 変更点
- storyboardでshareボタンとsearchボタンからの動線を削除
- ShareViewControllerではsearchボタンを隠す
- SearchViewControllerではshareボタンを隠す

## どうやって使うか

## なぜ変更/追加したか
無限に「共有画面」と「検索画面」のボタンを押せてしまう導線を消すため

## スクショ(UI変更がある場合)

## 備考
