### PR TITLE
ホーム画面のセルの表示を追加実装

### DIFF
--- a/ToDoAppEx/Base.lproj/Main.storyboard
+++ b/ToDoAppEx/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xix-qy-TEu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xix-qy-TEu">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -585,7 +585,7 @@
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="PQY-BQ-Qe1" userLabel="Title StackView">
-                                                            <rect key="frame" x="91.333333333333329" y="10" width="141.33333333333337" height="76"/>
+                                                            <rect key="frame" x="91.000000000000014" y="10" width="141.33333333333337" height="76"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="19" translatesAutoresizingMaskIntoConstraints="NO" id="Y48-6c-Lkq">
                                                                     <rect key="frame" x="0.0" y="0.0" width="141.33333333333334" height="52"/>
@@ -616,10 +616,10 @@
                                                             </subviews>
                                                         </stackView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="mbV-e9-398" userLabel="Date StackView">
-                                                            <rect key="frame" x="287.66666666666669" y="5" width="82.333333333333314" height="86"/>
+                                                            <rect key="frame" x="287.33333333333331" y="5" width="82.666666666666686" height="86"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="PoY-YC-mDx">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="82.333333333333329" height="40.666666666666664"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="82.666666666666671" height="40.666666666666664"/>
                                                                     <attributedString key="attributedText">
                                                                         <fragment content="Start: MM/DD">
                                                                             <attributes>
@@ -630,7 +630,7 @@
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="15" translatesAutoresizingMaskIntoConstraints="NO" id="5SC-Tf-o9a">
-                                                                    <rect key="frame" x="0.0" y="45.666666666666657" width="82.333333333333329" height="40.333333333333343"/>
+                                                                    <rect key="frame" x="0.0" y="45.666666666666657" width="82.666666666666671" height="40.333333333333343"/>
                                                                     <attributedString key="attributedText">
                                                                         <fragment content="残り○日">
                                                                             <attributes>
@@ -662,6 +662,7 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="categoryLabel" destination="J1a-xQ-kMm" id="eJ9-Bt-JsI"/>
+                                            <outlet property="checkImage" destination="I3a-Vj-eQb" id="CBj-CH-fIj"/>
                                             <outlet property="imageView" destination="I3a-Vj-eQb" id="hBa-I7-lQr"/>
                                             <outlet property="remainDayLabel" destination="5SC-Tf-o9a" id="uuZ-2E-PjP"/>
                                             <outlet property="startDateLabel" destination="PoY-YC-mDx" id="2aL-gg-FEe"/>
@@ -787,8 +788,8 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="5wf-5X-na8"/>
-        <segue reference="4H5-DS-sG8"/>
+        <segue reference="BJx-tT-wAk"/>
+        <segue reference="38O-Zn-vJk"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="Logo-1" width="250" height="174"/>

--- a/ToDoAppEx/Utils/Date+Extension.swift
+++ b/ToDoAppEx/Utils/Date+Extension.swift
@@ -8,6 +8,14 @@
 import UIKit
 
 extension Date {
+    func toStringWithCurrentLocaleDay() -> String {
+        let formatter = DateFormatter()
+        formatter.timeZone = TimeZone.current
+        formatter.locale = Locale.current
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: self)
+    }
+
     func toStringWithCurrentLocale() -> String {
         let formatter = DateFormatter()
         formatter.timeZone = TimeZone.current
@@ -15,12 +23,31 @@ extension Date {
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         return formatter.string(from: self)
     }
+
     func toStringWithCurrentLocaleMillis() -> String {
         let formatter = DateFormatter()
         formatter.timeZone = TimeZone.current
         formatter.locale = Locale.current
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
         return formatter.string(from: self)
+    }
+
+
+    /// 日付と引数の日付を比較して判定するメソッド
+    /// - Parameter targetDay: 日付の比較対象
+    /// - Returns: 比較対象の日付より前または同じ→true、比較対象より後→false
+    func compareDate(targetDay: String) -> Bool {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+
+        let compareResult = targetDay.compare(self.toStringWithCurrentLocaleDay())
+
+        switch compareResult {
+        case .orderedAscending, .orderedSame:
+            return true
+        case .orderedDescending:
+            return false
+        }
     }
 
     func getIntervalDate(start: String, end: String) -> Int {

--- a/ToDoAppEx/View/ImageCell.swift
+++ b/ToDoAppEx/View/ImageCell.swift
@@ -22,9 +22,16 @@ final class ImageCell: UITableViewCell {
         categoryLabel.text = category
         print(titleLabel.text ?? "")
 
-        setDate(startDate: startDate, endDate: endDate) { start, interval in
-            startDateLabel.text = start
-            remainDayLabel.text = "残り\(interval)日"
+        setDate(startDate: startDate, endDate: endDate) { end, interval in
+            startDateLabel.text = "期限日: \(end)"
+            if (interval > 0) {
+                remainDayLabel.text = "残り\(interval)日"
+            } else if (interval == 0) {
+                remainDayLabel.text = "本日"
+            } else {
+                remainDayLabel.text = "期限切れ"
+                remainDayLabel.textColor = .red
+            }
         }
 
         if status {
@@ -38,10 +45,14 @@ final class ImageCell: UITableViewCell {
 
     // 開始日と終了日から残り日数を取得するメソッド
     private func setDate(startDate: String, endDate: String,
-                         operation: (_ start: String, _ end: String) -> Void) {
-        let start = String(startDate.prefix(10))
+                         operation: (_ end: String, _ interval: Int) -> Void) {
+        let today = Date()
+        // 表示日がタスクの開始日より前かを判定する
+        let isTodayBeforeStart = today.compareDate(targetDay: startDate)
+        let start = isTodayBeforeStart ? today.toStringWithCurrentLocaleDay() :String(startDate.prefix(10))
         let end = String(endDate.prefix(10))
-        let interval = String(Date().getIntervalDate(start: start, end: end))
-        operation(start, interval)
+
+        let interval = Date().getIntervalDate(start: start, end: end)
+        operation(end, interval)
     }
 }

--- a/ToDoAppEx/View/ImageCell.swift
+++ b/ToDoAppEx/View/ImageCell.swift
@@ -26,8 +26,10 @@ final class ImageCell: UITableViewCell {
             startDateLabel.text = "期限日: \(end)"
             if (interval > 0) {
                 remainDayLabel.text = "残り\(interval)日"
+                remainDayLabel.textColor = .black
             } else if (interval == 0) {
                 remainDayLabel.text = "本日"
+                remainDayLabel.textColor = .black
             } else {
                 remainDayLabel.text = "期限切れ"
                 remainDayLabel.textColor = .red

--- a/ToDoAppEx/View/ImageCell.swift
+++ b/ToDoAppEx/View/ImageCell.swift
@@ -13,13 +13,14 @@ final class ImageCell: UITableViewCell {
 	@IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var categoryLabel: UILabel!
     @IBOutlet private weak var startDateLabel: UILabel!
-    @IBOutlet weak var remainDayLabel: UILabel!
+    @IBOutlet private weak var remainDayLabel: UILabel!
+    @IBOutlet weak var checkImage: UIImageView!
 
     func configure(image: String, title: String, category: String,
                    startDate: String, endDate: String, status: Bool) {
 		titleLabel.text = title
         categoryLabel.text = category
-        print(titleLabel.text)
+        print(titleLabel.text ?? "")
 
         setDate(startDate: startDate, endDate: endDate) { start, interval in
             startDateLabel.text = start
@@ -27,12 +28,15 @@ final class ImageCell: UITableViewCell {
         }
 
         if status {
-            titleImageView.image = UIImage(named: image)!
+            titleImageView.image = UIImage(named: "check")!
+        } else {
+            titleImageView.image = UIImage()
         }
         print(startDate)
         print(endDate)
 	}
 
+    // 開始日と終了日から残り日数を取得するメソッド
     private func setDate(startDate: String, endDate: String,
                          operation: (_ start: String, _ end: String) -> Void) {
         let start = String(startDate.prefix(10))

--- a/ToDoAppEx/ViewController/HomeViewController.swift
+++ b/ToDoAppEx/ViewController/HomeViewController.swift
@@ -64,6 +64,12 @@ extension HomeViewController {
         }
     }
 
+    private func changeStatusToDoItem(index: Int) {
+        try! realm.write {
+            todoList[index].status = !todoList[index].status        }
+        reload()
+    }
+
     private func reload() {
         tableView.reloadData()
     }
@@ -91,4 +97,10 @@ extension HomeViewController: UITableViewDataSource, UITableViewDelegate{
 				   forRowAt indexPath: IndexPath) {
 		deleteTodoItem(at: indexPath.row)
 	}
+
+    // ToDoのステータス状態を変更するメソッド
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        changeStatusToDoItem(index: indexPath.row)
+    }
+
 }

--- a/ToDoAppEx/ViewController/LoginViewController.swift
+++ b/ToDoAppEx/ViewController/LoginViewController.swift
@@ -11,7 +11,9 @@ import RealmSwift
 class LoginViewController: UIViewController {
     @IBOutlet weak var email: UITextField!
     @IBOutlet weak var password: UITextField!
+
     let userDefaults = UserDefaults()
+
     @IBAction private func login(_ sender: Any) {
         let serverRequest: ServerRequest = ServerRequest()
         serverRequest.sendServerRequest(
@@ -90,6 +92,7 @@ class LoginViewController: UIViewController {
             return
         }
     }
+    
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         self.view.endEditing(true)
     }


### PR DESCRIPTION
## 変更点
- ホーム画面にあるセルをタップするとチェックボタンが表示/非表示で切り替わる
- タスクの設定した期限日に応じてセル内の表示が切り替わる
   - アプリ起動日が期限日より前→"残り○日"
   - アプリ起動日が期限日と同じ→"本日"
   - アプリ起動日が期限日より後→"期限切れ"

## どうやって使うか
- タスク編集画面から期限日を設定して動作が確認できる

## なぜ変更/追加したか
- タスク管理アプリでタスクの期限を設定する以上、ホーム画面でいつまでにする必要があるかを把握できるほうが良いため

## スクショ(UI変更がある場合)
![Screen Shot 2022-06-12 at 9 17 39](https://user-images.githubusercontent.com/72324850/173209329-bd35695c-36d6-4808-9850-a8a65db7654b.png)


## 備考
- 特になし