### PR TITLE
[add] Realmを管理するmanagerをシングルトンとして定義して追加

### DIFF
--- a/ToDoAppEx.xcodeproj/project.pbxproj
+++ b/ToDoAppEx.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		9F5F49BC26094FAA000C2E0A /* ImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5F49BB26094FAA000C2E0A /* ImageCell.swift */; };
 		9F6384C126460B93001DFEBD /* CustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6384C026460B93001DFEBD /* CustomView.swift */; };
 		9F6384C626460BCA001DFEBD /* CustomView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9F6384C526460BCA001DFEBD /* CustomView.xib */; };
+		9FA692BB285B48300066850F /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA692BA285B48300066850F /* RealmManager.swift */; };
 		A0FCB734FFBD16DCABD42CFE /* Pods_ToDoAppExTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3C4A4A23D159A521BF73F0E /* Pods_ToDoAppExTests.framework */; };
 		F421746426AB9B5000B133F1 /* ServerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F421746326AB9B5000B133F1 /* ServerRequest.swift */; };
 		F421746626ABAC2500B133F1 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F421746526ABAC2500B133F1 /* Date+Extension.swift */; };
@@ -62,6 +63,7 @@
 		9F5F49BB26094FAA000C2E0A /* ImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCell.swift; sourceTree = "<group>"; };
 		9F6384C026460B93001DFEBD /* CustomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomView.swift; sourceTree = "<group>"; };
 		9F6384C526460BCA001DFEBD /* CustomView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomView.xib; sourceTree = "<group>"; };
+		9FA692BA285B48300066850F /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
 		A1895C9BD803A6D3D6D5D757 /* Pods-ToDoAppEx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ToDoAppEx.release.xcconfig"; path = "Target Support Files/Pods-ToDoAppEx/Pods-ToDoAppEx.release.xcconfig"; sourceTree = "<group>"; };
 		B589D8C785E573BB12FBFB59 /* Pods-ToDoAppEx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ToDoAppEx.debug.xcconfig"; path = "Target Support Files/Pods-ToDoAppEx/Pods-ToDoAppEx.debug.xcconfig"; sourceTree = "<group>"; };
 		BBD0896660E6E0BD1A1F8FA7 /* Pods_ToDoAppEx_ToDoAppExUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ToDoAppEx_ToDoAppExUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -192,6 +194,7 @@
 			isa = PBXGroup;
 			children = (
 				F421746526ABAC2500B133F1 /* Date+Extension.swift */,
+				9FA692BA285B48300066850F /* RealmManager.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -506,6 +509,7 @@
 				F47286092622CC6F002D6F86 /* SignupViewController.swift in Sources */,
 				9F5F49BC26094FAA000C2E0A /* ImageCell.swift in Sources */,
 				F4F008F527C571D500B44B80 /* AskPasswordSettingViewController.swift in Sources */,
+				9FA692BB285B48300066850F /* RealmManager.swift in Sources */,
 				F48F3B0E25F447B6001E5342 /* SettingViewController.swift in Sources */,
 				F4C6A3482744013B007E60F2 /* ShareAccountCell.swift in Sources */,
 				F4FC931A277CF43B001B9A36 /* ShareTodoItemListViewController.swift in Sources */,

--- a/ToDoAppEx/Utils/RealmManager.swift
+++ b/ToDoAppEx/Utils/RealmManager.swift
@@ -1,0 +1,84 @@
+//
+//  RealmManager.swift
+//  ToDoAppEx
+//
+//  Created by Naoyuki Kan on 2022/06/16.
+//
+
+import Foundation
+import RealmSwift
+
+
+/// Realmを管理するManager
+final class RealmManager {
+    // シングルトンとして使用
+    public static let shared = RealmManager()
+
+    private var realm: Realm
+
+    private init() {
+        realm = try! Realm()
+    }
+
+    /// Realmからデータを取得する
+    ///
+    /// Objectに準拠した型を指定してRealmからデータをReselt<Object>として取得する
+    func getItemInRealm<T>(type: T.Type) -> Results<T> where T: Object {
+        return realm.objects(type.self)
+    }
+
+    /// Realmにデータを追加する
+    ///
+    /// 与えられたObjectのItemを追加する
+    func writeItem<T>(_ value: T) where T: Object {
+        do {
+            try realm.write {
+                realm.add(value)
+                print("新しいリスト追加")
+            }
+        } catch {
+            print("新しいタスクの書き込みに失敗")
+        }
+    }
+
+    /// Realmのデータを削除する
+    ///
+    /// 与えられたObjectのitemを削除する
+    func deleteItem(item: ObjectBase) {
+        do {
+            try realm.write {
+                print("\(item)を削除")
+                realm.delete(item)
+            }
+        } catch {
+            print("削除に失敗")
+        }
+    }
+
+    /// Realmにあるデータを全て削除する
+    func deleteAllItem(){
+        do {
+            try realm.write {
+                print("すべてのRealmのデータを削除")
+                realm.deleteAll()
+            }
+        } catch {
+            print("すべてのRealmのデータ削除に失敗")
+        }
+    }
+
+    /// ToDoItemの項目を修正する
+    ///
+    /// 独自の書き込みが必要になるため専用で置く
+    func changeStatusToDoItem<T>(type: T.Type, index: Int) where T: TodoItem {
+        let list = getItemInRealm(type: type.self)
+
+        do {
+            try realm.write {
+                list[index].status = !list[index].status
+            }
+        } catch {
+            print("ステータスの変更に失敗しました")
+        }
+    }
+}

--- a/ToDoAppEx/ViewController/EditViewController.swift
+++ b/ToDoAppEx/ViewController/EditViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import RealmSwift
 
 class EditViewController: UIViewController {
 
@@ -23,8 +22,9 @@ class EditViewController: UIViewController {
             self.view.endEditing(true)
     }
 
-    func setToDoItem(contents: Results<TodoItem>, users: Results<User>, list: String, category: String) -> TodoItem {
+    func setToDoItem(list: String, category: String) -> TodoItem {
         let toDo = TodoItem()
+        let users = RealmManager.shared.getItemInRealm(type: User.self)
         let uuid = UUID()
         let date = Date()
         toDo.itemid = uuid.uuidString
@@ -45,12 +45,9 @@ class EditViewController: UIViewController {
         guard let newList = textField.text, !newList.isEmpty else { return }
         guard let newCategory = categoryTextField.text, !newCategory.isEmpty else { return }
 
-        let realm = try! Realm()
-        let toDo = setToDoItem(contents: realm.objects(TodoItem.self), users: realm.objects(User.self), list: newList, category: newCategory)
-        try! realm.write {
-            realm.add(toDo)
-            print("新しいリスト追加：\(newList)")
-        }
+        let toDo = setToDoItem(list: newList, category: newCategory)
+
+        RealmManager.shared.writeItem(toDo)
 
         let serverRequest: ServerRequest = ServerRequest()
         serverRequest.sendServerRequest(

--- a/ToDoAppEx/ViewController/HomeViewController.swift
+++ b/ToDoAppEx/ViewController/HomeViewController.swift
@@ -20,11 +20,10 @@ class HomeViewController: UIViewController {
         super.viewDidLoad()
 		print(#function)
 
-		realm = try! Realm()
-		todoList = realm.objects(TodoItem.self)
-		token = todoList.observe { [weak self] _ in
-		  self?.reload()
-		}
+        realm = try! Realm()
+
+        // ToDoListをRealmから取得してオブザーバーを仕掛ける
+        setTodoListConfig()
 
         // TableViewの設定メソッド
         setTableViewConfig()
@@ -45,8 +44,14 @@ class HomeViewController: UIViewController {
 }
 
 
-
 extension HomeViewController {
+    private func setTodoListConfig() {
+        todoList = RealmManager.shared.getItemInRealm(type: TodoItem.self)
+        token = todoList.observe { [weak self] _ in
+          self?.reload()
+        }
+    }
+
     private func setTableViewConfig() {
         tableView.dataSource = self
         tableView.delegate = self
@@ -59,14 +64,11 @@ extension HomeViewController {
     }
 
     private func deleteTodoItem(at index: Int) {
-        try! realm.write {
-            realm.delete(todoList[index])
-        }
+        RealmManager.shared.deleteItem(item: todoList[index])
     }
 
     private func changeStatusToDoItem(index: Int) {
-        try! realm.write {
-            todoList[index].status = !todoList[index].status        }
+        RealmManager.shared.changeStatusToDoItem(type: TodoItem.self, index: index)
         reload()
     }
 

--- a/ToDoAppEx/ViewController/HomeViewController.swift
+++ b/ToDoAppEx/ViewController/HomeViewController.swift
@@ -9,9 +9,7 @@ import UIKit
 import RealmSwift
 
 class HomeViewController: UIViewController {
-
 	private var todoList: Results<TodoItem>!
-	private var realm: Realm!
 	private var token: NotificationToken?
 
 	@IBOutlet private weak var tableView: UITableView!
@@ -19,8 +17,6 @@ class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 		print(#function)
-
-        realm = try! Realm()
 
         // ToDoListをRealmから取得してオブザーバーを仕掛ける
         setTodoListConfig()


### PR DESCRIPTION
## 変更点
- RealmをそれぞれのViewControllerから操作するのではなく、Managerから統一して操作するようにする

## どうやって使うか
- RealmManagerのシングルトンを取得してそれぞれのメソッドで用途に応じて使用する

## なぜ変更/追加したか
- Realmのデータを取得、保存など行う処理がそれぞれのViewControllerからRealmをインスタンス化して処理されていたため
- 今後に置いてもRealmを操作する処理が追加されることを見越すと一元で管理したほうが良いため

## スクショ(UI変更がある場合)
- UIの変更なし

## 備考
- ToDoのステータス変更だけは独自の操作なのでManagerに、独自のメソッドとして置くことになりました、、、
- もっと良い方法などあれば、、、