### PR TITLE
ホーム画面のタスクの編集機能を追加

### DIFF
--- a/ToDoAppEx.xcodeproj/project.pbxproj
+++ b/ToDoAppEx.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		9F5F49BC26094FAA000C2E0A /* ImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5F49BB26094FAA000C2E0A /* ImageCell.swift */; };
 		9F6384C126460B93001DFEBD /* CustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6384C026460B93001DFEBD /* CustomView.swift */; };
 		9F6384C626460BCA001DFEBD /* CustomView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9F6384C526460BCA001DFEBD /* CustomView.xib */; };
+		9F9647E128756EF100B7244E /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9647E028756EF100B7244E /* String+Extension.swift */; };
 		9FA692BB285B48300066850F /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA692BA285B48300066850F /* RealmManager.swift */; };
 		A0FCB734FFBD16DCABD42CFE /* Pods_ToDoAppExTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3C4A4A23D159A521BF73F0E /* Pods_ToDoAppExTests.framework */; };
 		F421746426AB9B5000B133F1 /* ServerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F421746326AB9B5000B133F1 /* ServerRequest.swift */; };
@@ -63,6 +64,7 @@
 		9F5F49BB26094FAA000C2E0A /* ImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCell.swift; sourceTree = "<group>"; };
 		9F6384C026460B93001DFEBD /* CustomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomView.swift; sourceTree = "<group>"; };
 		9F6384C526460BCA001DFEBD /* CustomView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomView.xib; sourceTree = "<group>"; };
+		9F9647E028756EF100B7244E /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		9FA692BA285B48300066850F /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
 		A1895C9BD803A6D3D6D5D757 /* Pods-ToDoAppEx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ToDoAppEx.release.xcconfig"; path = "Target Support Files/Pods-ToDoAppEx/Pods-ToDoAppEx.release.xcconfig"; sourceTree = "<group>"; };
 		B589D8C785E573BB12FBFB59 /* Pods-ToDoAppEx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ToDoAppEx.debug.xcconfig"; path = "Target Support Files/Pods-ToDoAppEx/Pods-ToDoAppEx.debug.xcconfig"; sourceTree = "<group>"; };
@@ -195,6 +197,7 @@
 			children = (
 				F421746526ABAC2500B133F1 /* Date+Extension.swift */,
 				9FA692BA285B48300066850F /* RealmManager.swift */,
+				9F9647E028756EF100B7244E /* String+Extension.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -516,6 +519,7 @@
 				F4FC931C277D04F2001B9A36 /* ShareTodoItemCell.swift in Sources */,
 				F48F3B0925F447A3001E5342 /* EditViewController.swift in Sources */,
 				F421746626ABAC2500B133F1 /* Date+Extension.swift in Sources */,
+				9F9647E128756EF100B7244E /* String+Extension.swift in Sources */,
 				F44C387E26A67C8400D41ED7 /* User.swift in Sources */,
 				F48F3ADA25F3D8E8001E5342 /* HomeViewController.swift in Sources */,
 				F48F3AD625F3D8E8001E5342 /* AppDelegate.swift in Sources */,

--- a/ToDoAppEx/API/ServerRequest.swift
+++ b/ToDoAppEx/API/ServerRequest.swift
@@ -16,6 +16,7 @@ class ServerRequest {
             request.httpBody = try JSONSerialization.data(withJSONObject: params, options: .prettyPrinted)
             let task:URLSessionDataTask = URLSession.shared.dataTask(with: request as URLRequest, completionHandler: {(data,response,error) -> Void in
                 if error == nil {
+                    print("server response: \(String(describing: response))")
                     completion(data!)
                 } else {
                     print("server error:\(String(describing:error))")

--- a/ToDoAppEx/Base.lproj/Main.storyboard
+++ b/ToDoAppEx/Base.lproj/Main.storyboard
@@ -140,6 +140,7 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="addButton" destination="2ZF-TH-hQY" id="oTC-0z-Jzt"/>
                         <outlet property="categoryTextField" destination="xzP-DY-4vV" id="XZe-qZ-Ilp"/>
                         <outlet property="endDateTime" destination="rzz-uF-xuG" id="81W-Ll-4Yf"/>
                         <outlet property="startDateTime" destination="NdB-MM-xel" id="u11-P3-KHt"/>

--- a/ToDoAppEx/Utils/Date+Extension.swift
+++ b/ToDoAppEx/Utils/Date+Extension.swift
@@ -32,7 +32,6 @@ extension Date {
         return formatter.string(from: self)
     }
 
-
     /// 日付と引数の日付を比較して判定するメソッド
     /// - Parameter targetDay: 日付の比較対象
     /// - Returns: 比較対象の日付より前または同じ→true、比較対象より後→false

--- a/ToDoAppEx/Utils/RealmManager.swift
+++ b/ToDoAppEx/Utils/RealmManager.swift
@@ -67,7 +67,7 @@ final class RealmManager {
         }
     }
 
-    /// ToDoItemの項目を修正する
+    /// ToDoItemのステータスを修正する
     ///
     /// 独自の書き込みが必要になるため専用で置く
     func changeStatusToDoItem<T>(type: T.Type, index: Int) where T: TodoItem {
@@ -79,6 +79,22 @@ final class RealmManager {
             }
         } catch {
             print("ステータスの変更に失敗しました")
+        }
+    }
+
+    /// ToDoItemの内容を編集する
+    func editToDoItem(item: ItemData, index: Int) {
+        let list = getItemInRealm(type: TodoItem.self)
+
+        do {
+            try realm.write {
+                list[index].title = item.title
+                list[index].category = item.category
+                list[index].startdate = item.startDate
+                list[index].enddate = item.endDate
+            }
+        } catch {
+            print("アイテムの編集に失敗しました")
         }
     }
 }

--- a/ToDoAppEx/Utils/String+Extension.swift
+++ b/ToDoAppEx/Utils/String+Extension.swift
@@ -6,3 +6,12 @@
 //
 
 import Foundation
+
+extension String {
+    func dateFromString(format: String) -> Date {
+        let formatter: DateFormatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.dateFormat = format
+        return formatter.date(from: self)!
+    }
+}

--- a/ToDoAppEx/Utils/String+Extension.swift
+++ b/ToDoAppEx/Utils/String+Extension.swift
@@ -1,0 +1,8 @@
+//
+//  String+Extension.swift
+//  ToDoAppEx
+//
+//  Created by Naoyuki Kan on 2022/07/06.
+//
+
+import Foundation

--- a/ToDoAppEx/ViewController/EditViewController.swift
+++ b/ToDoAppEx/ViewController/EditViewController.swift
@@ -6,10 +6,12 @@
 //
 
 import UIKit
+import RealmSwift
 
+// 編集画面のタイプを管理するEnum
 enum EditType {
     case create
-    case edit
+    case edit(index: Int)
 }
 
 class EditViewController: UIViewController {
@@ -19,6 +21,7 @@ class EditViewController: UIViewController {
     @IBOutlet weak var categoryTextField: UITextField!
     @IBOutlet weak var startDateTime: UIDatePicker!
     @IBOutlet weak var endDateTime: UIDatePicker!
+    @IBOutlet weak var addButton: UIButton!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -26,9 +29,11 @@ class EditViewController: UIViewController {
         switch type {
         case .create:
             print("新規作成の編集画面を構成")
-        case .edit:
+        case let .edit(index):
             print("既存タスク編集の編集画面を構成")
-            
+            addButton.setTitle("保存", for: .normal)
+            let todoList = RealmManager.shared.getItemInRealm(type: TodoItem.self)
+            setEditToDoItem(index: index, targetItem: todoList[index])
         }
     }
 
@@ -41,7 +46,23 @@ class EditViewController: UIViewController {
         self.type = type
     }
 
-    func setToDoItem(list: String, category: String) -> TodoItem {
+    func setEditToDoItem(index: Int, targetItem: TodoItem) {
+        textField.text = targetItem.title
+        categoryTextField.text = targetItem.category
+        startDateTime.date = targetItem.startdate.dateFromString(format: "yyyy/MM/dd HH:mm:ss")
+        endDateTime.date = targetItem.enddate.dateFromString(format: "yyyy/MM/dd HH:mm:ss")
+    }
+
+    func editToDoItem(title: String, category: String, index: Int) {
+        let item = ItemData(title: title,
+                            category: category,
+                            startDate: startDateTime.date.toStringWithCurrentLocale().description,
+                            endDate: endDateTime.date.toStringWithCurrentLocale().description)
+
+        RealmManager.shared.editToDoItem(item: item, index: index)
+    }
+
+    func createToDoItem(title: String, category: String) -> TodoItem {
         let toDo = TodoItem()
         let users = RealmManager.shared.getItemInRealm(type: User.self)
         let uuid = UUID()
@@ -50,7 +71,7 @@ class EditViewController: UIViewController {
         toDo.accountname = users[0].accountname
         // FIXME: 現状は画像の種類が一枚なので固定値
         toDo.image = "check"
-        toDo.title = list
+        toDo.title = title
         toDo.category = category
         toDo.startdate = startDateTime.date.toStringWithCurrentLocale().description
         toDo.enddate = endDateTime.date.toStringWithCurrentLocale().description
@@ -60,35 +81,71 @@ class EditViewController: UIViewController {
     }
 
 	@IBAction func tapAddButton(_ sender: Any) {
-        guard let newList = textField.text, !newList.isEmpty else { return }
+        guard let newTitle = textField.text, !newTitle.isEmpty else { return }
         guard let newCategory = categoryTextField.text, !newCategory.isEmpty else { return }
 
-        let toDo = setToDoItem(list: newList, category: newCategory)
+        switch type {
+        case .create:
+            let toDo = createToDoItem(title: newTitle, category: newCategory)
+            RealmManager.shared.writeItem(toDo)
+            let serverRequest: ServerRequest = ServerRequest()
 
-        RealmManager.shared.writeItem(toDo)
+            serverRequest.sendServerRequest(
+                urlString: "http://tk2-235-27465.vs.sakura.ne.jp/insert_item",
+                params: [
+                    "itemid": toDo.itemid,
+                    "accountname": toDo.accountname,
+                    "title": toDo.title,
+                    "category": toDo.category,
+                    "startdate": toDo.startdate,
+                    "enddate": toDo.enddate,
+                    "image": toDo.image,
+                    "status": toDo.status
+                ],
+                completion: self.goToNext(data:)
+            )
+        case .edit(let index):
+            editToDoItem(title: newTitle, category: newCategory, index: index)
 
-        let serverRequest: ServerRequest = ServerRequest()
-        serverRequest.sendServerRequest(
-            urlString: "http://tk2-235-27465.vs.sakura.ne.jp/insert_item",
-            params: [
-                "itemid": toDo.itemid,
-                "accountname": toDo.accountname,
-                "title": toDo.title,
-                "category": toDo.category,
-                "startdate": toDo.startdate,
-                "enddate": toDo.enddate,
-                "image": toDo.image,
-                "status": toDo.status
-            ],
-            completion: self.goToNext(data:)
-        )
+            let serverRequest: ServerRequest = ServerRequest()
+            let todoList = RealmManager.shared.getItemInRealm(type: TodoItem.self)
+            let targetItem = todoList[index]
+
+            serverRequest.sendServerRequest(
+                urlString: "http://tk2-235-27465.vs.sakura.ne.jp/insert_item",
+                params: [
+                    "itemid": targetItem.itemid,
+                    "accountname": targetItem.accountname,
+                    "title": targetItem.title,
+                    "category": targetItem.category,
+                    "startdate": targetItem.startdate,
+                    "enddate": targetItem.enddate,
+                    "image": targetItem.image,
+                    "status": targetItem.status
+                ],
+                completion: self.closeScreen(data:)
+            )
+        }
     }
     
     private func goToNext(data: Data?) {
         DispatchQueue.main.async {
             let UINavigationController = self.tabBarController?.viewControllers?[1]
             self.tabBarController?.selectedViewController = UINavigationController
-
         }
     }
+
+    private func closeScreen(data: Data?) {
+        DispatchQueue.main.async {
+            self.dismiss(animated: true, completion: nil)
+        }
+    }
+}
+
+// 編集するToDoItemの情報を管理
+struct ItemData {
+    let title: String
+    let category: String
+    let startDate: String
+    let endDate: String
 }

--- a/ToDoAppEx/ViewController/EditViewController.swift
+++ b/ToDoAppEx/ViewController/EditViewController.swift
@@ -7,7 +7,13 @@
 
 import UIKit
 
+enum EditType {
+    case create
+    case edit
+}
+
 class EditViewController: UIViewController {
+    private var type = EditType.create
 
 	@IBOutlet weak var textField: UITextField!
     @IBOutlet weak var categoryTextField: UITextField!
@@ -16,10 +22,23 @@ class EditViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        switch type {
+        case .create:
+            print("新規作成の編集画面を構成")
+        case .edit:
+            print("既存タスク編集の編集画面を構成")
+            
+        }
     }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-            self.view.endEditing(true)
+        self.view.endEditing(true)
+    }
+
+    // 編集画面をボトムナビゲーションかホーム画面からかによって処理を分ける
+    func configure(type: EditType) {
+        self.type = type
     }
 
     func setToDoItem(list: String, category: String) -> TodoItem {

--- a/ToDoAppEx/ViewController/HomeViewController.swift
+++ b/ToDoAppEx/ViewController/HomeViewController.swift
@@ -50,6 +50,9 @@ extension HomeViewController {
             self.present(editVC, animated: true, completion: nil)
         }
 
+        let delete = UIAction(title: "削除", image: UIImage(systemName: "bag")) { action in
+            print("削除")
+            RealmManager.shared.deleteItem(item: self.todoList[index])
         }
 
         return UIMenu(title: "Menu", children: [edit, delete])
@@ -114,11 +117,6 @@ extension HomeViewController: UITableViewDataSource, UITableViewDelegate{
                        endDate: todoList[indexPath.row].enddate,
                        status: todoList[indexPath.row].status)
 		return cell
-	}
-
-	func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle,
-				   forRowAt indexPath: IndexPath) {
-		deleteTodoItem(at: indexPath.row)
 	}
 
     // ToDoのステータス状態を変更するメソッド

--- a/ToDoAppEx/ViewController/HomeViewController.swift
+++ b/ToDoAppEx/ViewController/HomeViewController.swift
@@ -42,26 +42,17 @@ class HomeViewController: UIViewController {
 
 extension HomeViewController {
     /// 吹き出しメニューを作成する
-    func makeContextMenu() -> UIMenu {
-        let fight = UIAction(title: "FIGHT", image: UIImage(systemName: "figure.wave")) { action in
+    func makeContextMenu(index: Int) -> UIMenu {
+        let edit = UIAction(title: "編集", image: UIImage(systemName: "figure.wave")) { action in
             print("編集")
             let editVC = self.storyboard?.instantiateViewController(withIdentifier: "EditViewController") as! EditViewController
+            editVC.configure(type: .edit(index: index))
             self.present(editVC, animated: true, completion: nil)
         }
 
-        let bag = UIAction(title: "BAG", image: UIImage(systemName: "bag")) { action in
-            print("bag")
         }
 
-        let pokemon = UIAction(title: "POKEMON", image: UIImage(systemName: "hare")) { action in
-            print("pokemon")
-        }
-
-        let run = UIAction(title: "RUN", image: UIImage(systemName: "figure.walk")) { action in
-            print("run")
-        }
-
-        return UIMenu(title: "Menu", children: [fight, bag, pokemon, run])
+        return UIMenu(title: "Menu", children: [edit, delete])
     }
 
     private func setTodoListConfig() {
@@ -101,9 +92,14 @@ extension HomeViewController: UITableViewDataSource, UITableViewDelegate{
 		return todoList.count
 	}
 
-    func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
-        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: { suggestedActions in
-            return self.makeContextMenu()
+    func tableView(_ tableView: UITableView,
+                   contextMenuConfigurationForRowAt indexPath: IndexPath,
+                   point: CGPoint) -> UIContextMenuConfiguration? {
+        let index = indexPath.row
+        return UIContextMenuConfiguration(identifier: nil,
+                                          previewProvider: nil,
+                                          actionProvider: { suggestedActions in
+            return self.makeContextMenu(index: index)
         })
     }
 

--- a/ToDoAppEx/ViewController/HomeViewController.swift
+++ b/ToDoAppEx/ViewController/HomeViewController.swift
@@ -42,7 +42,7 @@ class HomeViewController: UIViewController {
 
 extension HomeViewController {
     /// 吹き出しメニューを作成する
-    func makeContextMenu(index: Int) -> UIMenu {
+    private func makeContextMenu(index: Int) -> UIMenu {
         let edit = UIAction(title: "編集", image: UIImage(systemName: "figure.wave")) { action in
             print("編集")
             let editVC = self.storyboard?.instantiateViewController(withIdentifier: "EditViewController") as! EditViewController
@@ -52,10 +52,25 @@ extension HomeViewController {
 
         let delete = UIAction(title: "削除", image: UIImage(systemName: "bag")) { action in
             print("削除")
+            self.deleteServerData(index: index)
             RealmManager.shared.deleteItem(item: self.todoList[index])
         }
 
         return UIMenu(title: "Menu", children: [edit, delete])
+    }
+
+    private func deleteServerData(index: Int) {
+        let targetItem = todoList[index]
+        let serverRequest: ServerRequest = ServerRequest()
+
+        serverRequest.sendServerRequest(
+            urlString: "http://tk2-235-27465.vs.sakura.ne.jp/delete_item",
+            params: [
+                "itemid": targetItem.itemid,
+                "accountname": targetItem.accountname,
+            ],
+            completion: { (data: Data) -> Void in }
+        )
     }
 
     private func setTodoListConfig() {

--- a/ToDoAppEx/ViewController/HomeViewController.swift
+++ b/ToDoAppEx/ViewController/HomeViewController.swift
@@ -41,6 +41,29 @@ class HomeViewController: UIViewController {
 
 
 extension HomeViewController {
+    /// 吹き出しメニューを作成する
+    func makeContextMenu() -> UIMenu {
+        let fight = UIAction(title: "FIGHT", image: UIImage(systemName: "figure.wave")) { action in
+            print("編集")
+            let editVC = self.storyboard?.instantiateViewController(withIdentifier: "EditViewController") as! EditViewController
+            self.present(editVC, animated: true, completion: nil)
+        }
+
+        let bag = UIAction(title: "BAG", image: UIImage(systemName: "bag")) { action in
+            print("bag")
+        }
+
+        let pokemon = UIAction(title: "POKEMON", image: UIImage(systemName: "hare")) { action in
+            print("pokemon")
+        }
+
+        let run = UIAction(title: "RUN", image: UIImage(systemName: "figure.walk")) { action in
+            print("run")
+        }
+
+        return UIMenu(title: "Menu", children: [fight, bag, pokemon, run])
+    }
+
     private func setTodoListConfig() {
         todoList = RealmManager.shared.getItemInRealm(type: TodoItem.self)
         token = todoList.observe { [weak self] _ in
@@ -77,6 +100,12 @@ extension HomeViewController: UITableViewDataSource, UITableViewDelegate{
 	func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
 		return todoList.count
 	}
+
+    func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: { suggestedActions in
+            return self.makeContextMenu()
+        })
+    }
 
 	func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 		


### PR DESCRIPTION
## 変更点
- ホーム画面上のタスクのセル長押しで吹き出しメニューが表示される
- ホーム画面のタスクの削除機能も吹き出しメニューに統合した

## どうやって使うか
- ホーム画面のタスクを長押しして吹き出しのメニューから"編集"/"削除"を選択
   - 編集：編集画面がモーダルで開く
   - 削除：選択したタスクが削除される

## なぜ変更/追加したか
- 作成したタスクを編集する仕様に沿うため

## スクショ(UI変更がある場合
![Simulator Screen Shot - TestDevice - 2022-07-06 at 16 55 33](https://user-images.githubusercontent.com/72324850/177500753-d7232ac1-4d36-4fed-b5e9-815fa0a76e7a.png)
![Simulator Screen Shot - TestDevice - 2022-07-06 at 16 55 47](https://user-images.githubusercontent.com/72324850/177500760-119ad46b-2c75-441f-9d64-fab4e35430e9.png)



## 備考
- サーバーへの送信はIDが一致していれば修正される認識ですが、もし誤っている場合にはコメント下さい