### PR TITLE
検索画面の検索機能の追加

### DIFF
--- a/ToDoAppEx.xcodeproj/project.pbxproj
+++ b/ToDoAppEx.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		84342FDA46B03BB410F7DD02 /* Pods_ToDoAppEx.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09C99418B6C2D6AACD60CB37 /* Pods_ToDoAppEx.framework */; };
 		9B9012757307C49A4E96D15A /* Pods_ToDoAppEx_ToDoAppExUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BBD0896660E6E0BD1A1F8FA7 /* Pods_ToDoAppEx_ToDoAppExUITests.framework */; };
+		9F33584928AA406F003A5263 /* ImageCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9F33584828AA406F003A5263 /* ImageCell.xib */; };
 		9F5F499326058303000C2E0A /* TodoItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5F499226058303000C2E0A /* TodoItem.swift */; };
 		9F5F49BC26094FAA000C2E0A /* ImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5F49BB26094FAA000C2E0A /* ImageCell.swift */; };
 		9F6384C126460B93001DFEBD /* CustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6384C026460B93001DFEBD /* CustomView.swift */; };
@@ -60,6 +61,7 @@
 /* Begin PBXFileReference section */
 		09C99418B6C2D6AACD60CB37 /* Pods_ToDoAppEx.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ToDoAppEx.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E8C201AAE2FAC4C3E510521 /* Pods-ToDoAppEx-ToDoAppExUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ToDoAppEx-ToDoAppExUITests.debug.xcconfig"; path = "Target Support Files/Pods-ToDoAppEx-ToDoAppExUITests/Pods-ToDoAppEx-ToDoAppExUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		9F33584828AA406F003A5263 /* ImageCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ImageCell.xib; sourceTree = "<group>"; };
 		9F5F499226058303000C2E0A /* TodoItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoItem.swift; sourceTree = "<group>"; };
 		9F5F49BB26094FAA000C2E0A /* ImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCell.swift; sourceTree = "<group>"; };
 		9F6384C026460B93001DFEBD /* CustomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomView.swift; sourceTree = "<group>"; };
@@ -166,6 +168,7 @@
 		9FA2207F27ADE90300CFD239 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				9F33584828AA406F003A5263 /* ImageCell.xib */,
 				9F5F49BB26094FAA000C2E0A /* ImageCell.swift */,
 				9F6384C526460BCA001DFEBD /* CustomView.xib */,
 				9F6384C026460B93001DFEBD /* CustomView.swift */,
@@ -379,6 +382,7 @@
 				F48F3AE225F3D8EA001E5342 /* LaunchScreen.storyboard in Resources */,
 				9F6384C626460BCA001DFEBD /* CustomView.xib in Resources */,
 				F48F3ADF25F3D8EA001E5342 /* Assets.xcassets in Resources */,
+				9F33584928AA406F003A5263 /* ImageCell.xib in Resources */,
 				F48F3ADD25F3D8E8001E5342 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ToDoAppEx/Base.lproj/Main.storyboard
+++ b/ToDoAppEx/Base.lproj/Main.storyboard
@@ -424,8 +424,30 @@
                     <view key="view" contentMode="scaleToFill" id="EKs-56-T5u">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="xq2-wc-fjW">
+                                <rect key="frame" x="0.0" y="93" width="390" height="50"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="ldr-BS-AFe"/>
+                                </constraints>
+                                <textInputTraits key="textInputTraits"/>
+                            </searchBar>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="fcG-Zk-y7b">
+                                <rect key="frame" x="0.0" y="148" width="390" height="613"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </tableView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="XrZ-ms-aYk"/>
-                        <color key="backgroundColor" systemColor="systemTealColor"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="xq2-wc-fjW" firstAttribute="trailing" secondItem="XrZ-ms-aYk" secondAttribute="trailing" id="233-Bn-PtB"/>
+                            <constraint firstItem="fcG-Zk-y7b" firstAttribute="leading" secondItem="XrZ-ms-aYk" secondAttribute="leading" id="B6K-0q-yv3"/>
+                            <constraint firstItem="xq2-wc-fjW" firstAttribute="leading" secondItem="XrZ-ms-aYk" secondAttribute="leading" id="LdY-bJ-fbe"/>
+                            <constraint firstItem="XrZ-ms-aYk" firstAttribute="trailing" secondItem="fcG-Zk-y7b" secondAttribute="trailing" id="cLM-jD-aHc"/>
+                            <constraint firstItem="XrZ-ms-aYk" firstAttribute="bottom" secondItem="fcG-Zk-y7b" secondAttribute="bottom" id="dMq-bM-0eL"/>
+                            <constraint firstItem="fcG-Zk-y7b" firstAttribute="top" secondItem="xq2-wc-fjW" secondAttribute="bottom" constant="5" id="kee-Rz-Mlp"/>
+                            <constraint firstItem="xq2-wc-fjW" firstAttribute="top" secondItem="XrZ-ms-aYk" secondAttribute="top" constant="5" id="nG2-j7-7U2"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Search" id="S8T-II-nY2">
                         <barButtonItem key="rightBarButtonItem" title="Item" image="cloud" catalog="system" id="sEz-ds-nV0"/>
@@ -863,9 +885,6 @@
         </systemColor>
         <systemColor name="systemRedColor">
             <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemTealColor">
-            <color red="0.18823529411764706" green="0.69019607843137254" blue="0.7803921568627451" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemYellowColor">
             <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/ToDoAppEx/Base.lproj/Main.storyboard
+++ b/ToDoAppEx/Base.lproj/Main.storyboard
@@ -426,14 +426,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="xq2-wc-fjW">
-                                <rect key="frame" x="0.0" y="93" width="390" height="50"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="ldr-BS-AFe"/>
                                 </constraints>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="fcG-Zk-y7b">
-                                <rect key="frame" x="0.0" y="148" width="390" height="613"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="100" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="fcG-Zk-y7b">
+                                <rect key="frame" x="0.0" y="138" width="390" height="623"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                         </subviews>
@@ -445,8 +445,8 @@
                             <constraint firstItem="xq2-wc-fjW" firstAttribute="leading" secondItem="XrZ-ms-aYk" secondAttribute="leading" id="LdY-bJ-fbe"/>
                             <constraint firstItem="XrZ-ms-aYk" firstAttribute="trailing" secondItem="fcG-Zk-y7b" secondAttribute="trailing" id="cLM-jD-aHc"/>
                             <constraint firstItem="XrZ-ms-aYk" firstAttribute="bottom" secondItem="fcG-Zk-y7b" secondAttribute="bottom" id="dMq-bM-0eL"/>
-                            <constraint firstItem="fcG-Zk-y7b" firstAttribute="top" secondItem="xq2-wc-fjW" secondAttribute="bottom" constant="5" id="kee-Rz-Mlp"/>
-                            <constraint firstItem="xq2-wc-fjW" firstAttribute="top" secondItem="XrZ-ms-aYk" secondAttribute="top" constant="5" id="nG2-j7-7U2"/>
+                            <constraint firstItem="fcG-Zk-y7b" firstAttribute="top" secondItem="xq2-wc-fjW" secondAttribute="bottom" id="kee-Rz-Mlp"/>
+                            <constraint firstItem="xq2-wc-fjW" firstAttribute="top" secondItem="XrZ-ms-aYk" secondAttribute="top" id="nG2-j7-7U2"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Search" id="S8T-II-nY2">
@@ -454,6 +454,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="shareButton" destination="sEz-ds-nV0" id="Akl-kI-1wb"/>
+                        <outlet property="tableView" destination="fcG-Zk-y7b" id="QVA-qD-mMv"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CZE-Mh-WBF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -638,111 +639,6 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="100" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="648-kV-2vW">
                                 <rect key="frame" x="0.0" y="88" width="390" height="673"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="todoItem" rowHeight="96" id="BmC-PN-ANy" customClass="ImageCell" customModule="ToDoAppEx" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.666666030883789" width="390" height="96"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="BmC-PN-ANy" id="GZV-Fu-mX7">
-                                            <rect key="frame" x="0.0" y="0.0" width="390" height="96"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="IIG-IZ-XrF" userLabel="Cell StackView">
-                                                    <rect key="frame" x="10" y="0.0" width="370" height="96"/>
-                                                    <subviews>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="I3a-Vj-eQb" userLabel="image View">
-                                                            <rect key="frame" x="0.0" y="32.333333333333329" width="36" height="32"/>
-                                                            <color key="tintColor" red="0.96713835000000004" green="0.58129739759999999" blue="0.117292203" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" secondItem="I3a-Vj-eQb" secondAttribute="height" multiplier="1:1" id="tdC-5u-xaG"/>
-                                                            </constraints>
-                                                        </imageView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="PQY-BQ-Qe1" userLabel="Title StackView">
-                                                            <rect key="frame" x="91.000000000000014" y="10" width="141.33333333333337" height="76"/>
-                                                            <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="Y48-6c-Lkq">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="141.33333333333334" height="52"/>
-                                                                    <attributedString key="attributedText">
-                                                                        <fragment content="タイトル">
-                                                                            <attributes>
-                                                                                <font key="NSFont" metaFont="system" size="35"/>
-                                                                                <font key="NSOriginalFont" metaFont="system" size="35"/>
-                                                                            </attributes>
-                                                                        </fragment>
-                                                                    </attributedString>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="J1a-xQ-kMm">
-                                                                    <rect key="frame" x="0.0" y="52" width="141.33333333333334" height="24"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="24" id="Vov-pQ-PBP"/>
-                                                                    </constraints>
-                                                                    <attributedString key="attributedText">
-                                                                        <fragment content="ジャンル">
-                                                                            <attributes>
-                                                                                <font key="NSFont" metaFont="system" size="20"/>
-                                                                            </attributes>
-                                                                        </fragment>
-                                                                    </attributedString>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                            </subviews>
-                                                        </stackView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="mbV-e9-398" userLabel="Date StackView">
-                                                            <rect key="frame" x="287.33333333333331" y="5" width="82.666666666666686" height="86"/>
-                                                            <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="PoY-YC-mDx">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="82.666666666666671" height="40.666666666666664"/>
-                                                                    <attributedString key="attributedText">
-                                                                        <fragment content="Start: MM/DD">
-                                                                            <attributes>
-                                                                                <font key="NSFont" metaFont="system"/>
-                                                                            </attributes>
-                                                                        </fragment>
-                                                                    </attributedString>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="15" translatesAutoresizingMaskIntoConstraints="NO" id="5SC-Tf-o9a">
-                                                                    <rect key="frame" x="0.0" y="45.666666666666657" width="82.666666666666671" height="40.333333333333343"/>
-                                                                    <attributedString key="attributedText">
-                                                                        <fragment content="残り○日">
-                                                                            <attributes>
-                                                                                <font key="NSFont" metaFont="system" size="15"/>
-                                                                            </attributes>
-                                                                        </fragment>
-                                                                    </attributedString>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                            </subviews>
-                                                        </stackView>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstItem="I3a-Vj-eQb" firstAttribute="top" secondItem="IIG-IZ-XrF" secondAttribute="top" constant="30" id="5UM-QJ-Ljz"/>
-                                                        <constraint firstAttribute="bottom" secondItem="mbV-e9-398" secondAttribute="bottom" constant="5" id="Bnt-gX-aGS"/>
-                                                        <constraint firstItem="PQY-BQ-Qe1" firstAttribute="top" secondItem="IIG-IZ-XrF" secondAttribute="top" constant="10" id="JEe-cS-c8e"/>
-                                                        <constraint firstItem="mbV-e9-398" firstAttribute="top" secondItem="IIG-IZ-XrF" secondAttribute="top" constant="5" id="WgT-DW-Jwd"/>
-                                                        <constraint firstAttribute="bottom" secondItem="I3a-Vj-eQb" secondAttribute="bottom" constant="30" id="bn4-fp-KWf"/>
-                                                        <constraint firstAttribute="bottom" secondItem="PQY-BQ-Qe1" secondAttribute="bottom" constant="10" id="fwx-c3-7t9"/>
-                                                    </constraints>
-                                                </stackView>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="IIG-IZ-XrF" firstAttribute="leading" secondItem="GZV-Fu-mX7" secondAttribute="leading" constant="10" id="ChO-T0-zAg"/>
-                                                <constraint firstItem="IIG-IZ-XrF" firstAttribute="top" secondItem="GZV-Fu-mX7" secondAttribute="top" id="NgD-TB-8uF"/>
-                                                <constraint firstAttribute="trailing" secondItem="IIG-IZ-XrF" secondAttribute="trailing" constant="10" id="XDw-yz-i9v"/>
-                                                <constraint firstAttribute="bottom" secondItem="IIG-IZ-XrF" secondAttribute="bottom" id="lVo-u0-Glc"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <outlet property="categoryLabel" destination="J1a-xQ-kMm" id="eJ9-Bt-JsI"/>
-                                            <outlet property="checkImage" destination="I3a-Vj-eQb" id="CBj-CH-fIj"/>
-                                            <outlet property="imageView" destination="I3a-Vj-eQb" id="hBa-I7-lQr"/>
-                                            <outlet property="remainDayLabel" destination="5SC-Tf-o9a" id="uuZ-2E-PjP"/>
-                                            <outlet property="startDateLabel" destination="PoY-YC-mDx" id="2aL-gg-FEe"/>
-                                            <outlet property="titleImageView" destination="I3a-Vj-eQb" id="J2h-xa-dSM"/>
-                                            <outlet property="titleLabel" destination="Y48-6c-Lkq" id="Fwu-Ui-kiI"/>
-                                        </connections>
-                                    </tableViewCell>
-                                </prototypes>
                             </tableView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="dOU-pf-bRW"/>
@@ -860,12 +756,11 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="5wf-5X-na8"/>
-        <segue reference="4H5-DS-sG8"/>
+        <segue reference="BJx-tT-wAk"/>
+        <segue reference="38O-Zn-vJk"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="Logo-1" width="250" height="174"/>
-        <image name="checkmark" catalog="system" width="128" height="114"/>
         <image name="cloud" catalog="system" width="128" height="88"/>
         <image name="gearshape" catalog="system" width="128" height="121"/>
         <image name="house.fill" catalog="system" width="128" height="106"/>

--- a/ToDoAppEx/Base.lproj/Main.storyboard
+++ b/ToDoAppEx/Base.lproj/Main.storyboard
@@ -453,6 +453,7 @@
                         <barButtonItem key="rightBarButtonItem" title="Item" image="cloud" catalog="system" id="sEz-ds-nV0"/>
                     </navigationItem>
                     <connections>
+                        <outlet property="searchBar" destination="xq2-wc-fjW" id="Zr5-Cw-OJs"/>
                         <outlet property="shareButton" destination="sEz-ds-nV0" id="Akl-kI-1wb"/>
                         <outlet property="tableView" destination="fcG-Zk-y7b" id="QVA-qD-mMv"/>
                     </connections>

--- a/ToDoAppEx/Utils/RealmManager.swift
+++ b/ToDoAppEx/Utils/RealmManager.swift
@@ -67,11 +67,26 @@ final class RealmManager {
         }
     }
 
+    private func searchIndex(uuid: String, list: Results<TodoItem>) -> Int? {
+        var index = 0
+        for item in list {
+            if item.itemid == uuid {
+                return index
+            }
+            index = index + 1
+        }
+        return nil
+    }
+
     /// ToDoItemのステータスを修正する
     ///
     /// 独自の書き込みが必要になるため専用で置く
-    func changeStatusToDoItem<T>(type: T.Type, index: Int) where T: TodoItem {
+    func changeStatusToDoItem<T>(type: T.Type, uuid: String) where T: TodoItem {
         let list = getItemInRealm(type: type.self)
+        guard let index = searchIndex(uuid: uuid, list: list as! Results<TodoItem>) else {
+            print("ステータスの変更に失敗しました")
+            return
+        }
 
         do {
             try realm.write {

--- a/ToDoAppEx/View/ImageCell.xib
+++ b/ToDoAppEx/View/ImageCell.xib
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ImageCell" customModule="ToDoAppEx" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" restorationIdentifier="ImageCell" id="iN0-l3-epB" customClass="ImageCell" customModule="ToDoAppEx" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="492" height="100"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="a2T-3g-OoD" userLabel="Cell StackView">
+                    <rect key="frame" x="10" y="0.0" width="472" height="100"/>
+                    <subviews>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="I9p-A7-XHg" userLabel="image View">
+                            <rect key="frame" x="0.0" y="32" width="40" height="36.5"/>
+                            <color key="tintColor" red="0.96713835000000004" green="0.58129739759999999" blue="0.117292203" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="I9p-A7-XHg" secondAttribute="height" multiplier="1:1" id="2vl-79-kgF"/>
+                            </constraints>
+                        </imageView>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6tf-DG-0bb" userLabel="Title StackView">
+                            <rect key="frame" x="144" y="10" width="141.5" height="80"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="xY6-V6-J03">
+                                    <rect key="frame" x="0.0" y="0.0" width="141.5" height="56"/>
+                                    <attributedString key="attributedText">
+                                        <fragment content="タイトル">
+                                            <attributes>
+                                                <font key="NSFont" metaFont="system" size="35"/>
+                                                <font key="NSOriginalFont" metaFont="system" size="35"/>
+                                            </attributes>
+                                        </fragment>
+                                    </attributedString>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="ybp-Gz-gZV">
+                                    <rect key="frame" x="0.0" y="56" width="141.5" height="24"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="24" id="rdb-ww-beE"/>
+                                    </constraints>
+                                    <attributedString key="attributedText">
+                                        <fragment content="ジャンル">
+                                            <attributes>
+                                                <font key="NSFont" metaFont="system" size="20"/>
+                                            </attributes>
+                                        </fragment>
+                                    </attributedString>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="yR5-hV-z3B" userLabel="Date StackView">
+                            <rect key="frame" x="389.5" y="5" width="82.5" height="90"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="U7Z-y7-T05">
+                                    <rect key="frame" x="0.0" y="0.0" width="82.5" height="42.5"/>
+                                    <attributedString key="attributedText">
+                                        <fragment content="Start: MM/DD">
+                                            <attributes>
+                                                <font key="NSFont" metaFont="system"/>
+                                            </attributes>
+                                        </fragment>
+                                    </attributedString>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="15" translatesAutoresizingMaskIntoConstraints="NO" id="xeD-41-RUI">
+                                    <rect key="frame" x="0.0" y="47.5" width="82.5" height="42.5"/>
+                                    <attributedString key="attributedText">
+                                        <fragment content="残り○日">
+                                            <attributes>
+                                                <font key="NSFont" metaFont="system" size="15"/>
+                                            </attributes>
+                                        </fragment>
+                                    </attributedString>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="I9p-A7-XHg" secondAttribute="bottom" constant="30" id="3BZ-o0-7IG"/>
+                        <constraint firstAttribute="bottom" secondItem="6tf-DG-0bb" secondAttribute="bottom" constant="10" id="5ud-8Y-BlH"/>
+                        <constraint firstItem="I9p-A7-XHg" firstAttribute="top" secondItem="a2T-3g-OoD" secondAttribute="top" constant="30" id="Ky2-Cf-scI"/>
+                        <constraint firstItem="6tf-DG-0bb" firstAttribute="top" secondItem="a2T-3g-OoD" secondAttribute="top" constant="10" id="L6Q-uI-7ca"/>
+                        <constraint firstItem="yR5-hV-z3B" firstAttribute="top" secondItem="a2T-3g-OoD" secondAttribute="top" constant="5" id="bCs-be-MNi"/>
+                        <constraint firstAttribute="bottom" secondItem="yR5-hV-z3B" secondAttribute="bottom" constant="5" id="iLa-Kg-9y8"/>
+                    </constraints>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="Ye5-TO-Xbz"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="a2T-3g-OoD" secondAttribute="bottom" id="Aue-zc-0X5"/>
+                <constraint firstItem="a2T-3g-OoD" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="m3r-Zx-zRA"/>
+                <constraint firstAttribute="trailing" secondItem="a2T-3g-OoD" secondAttribute="trailing" constant="10" id="sEJ-wr-kUU"/>
+                <constraint firstItem="a2T-3g-OoD" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="10" id="tvX-k1-Z56"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="categoryLabel" destination="ybp-Gz-gZV" id="B2R-eV-INy"/>
+                <outlet property="remainDayLabel" destination="xeD-41-RUI" id="li2-7T-1Ec"/>
+                <outlet property="startDateLabel" destination="U7Z-y7-T05" id="maN-qe-75Y"/>
+                <outlet property="titleImageView" destination="I9p-A7-XHg" id="SSj-eM-n2E"/>
+                <outlet property="titleLabel" destination="xY6-V6-J03" id="noo-hH-BC4"/>
+            </connections>
+            <point key="canvasLocation" x="156.52173913043478" y="-168.08035714285714"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="checkmark" catalog="system" width="128" height="114"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/ToDoAppEx/ViewController/HomeViewController.swift
+++ b/ToDoAppEx/ViewController/HomeViewController.swift
@@ -84,6 +84,8 @@ extension HomeViewController {
         tableView.dataSource = self
         tableView.delegate = self
 
+        tableView.register(UINib(nibName: "ImageCell", bundle: nil), forCellReuseIdentifier: "ImageCell")
+
         // セルの高さを固定
         tableView.estimatedRowHeight = 100
         // 区切り線を左端まで伸ばす
@@ -123,7 +125,7 @@ extension HomeViewController: UITableViewDataSource, UITableViewDelegate{
 
 	func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 		
-		let cell = tableView.dequeueReusableCell(withIdentifier: "todoItem", for: indexPath) as! ImageCell
+		let cell = tableView.dequeueReusableCell(withIdentifier: "ImageCell", for: indexPath) as! ImageCell
 		// カスタムセルにRealmの情報を反映
 		cell.configure(image: todoList[indexPath.row].image,
 					   title: todoList[indexPath.row].title,

--- a/ToDoAppEx/ViewController/HomeViewController.swift
+++ b/ToDoAppEx/ViewController/HomeViewController.swift
@@ -98,7 +98,7 @@ extension HomeViewController {
     }
 
     private func changeStatusToDoItem(index: Int) {
-        RealmManager.shared.changeStatusToDoItem(type: TodoItem.self, index: index)
+        RealmManager.shared.changeStatusToDoItem(type: TodoItem.self, uuid: todoList[index].itemid)
         reload()
     }
 

--- a/ToDoAppEx/ViewController/SearchViewController.swift
+++ b/ToDoAppEx/ViewController/SearchViewController.swift
@@ -15,22 +15,6 @@ class SearchViewController: UIViewController {
         shareButton.tintColor = UIColor.clear
     }
 
-//    func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
-//        if(item.tag == 0) {
-//            let homeVC = storyboard?.instantiateViewController(withIdentifier: "ViewController") as! ViewController
-//            homeVC.modalPresentationStyle = .fullScreen
-//            self.present(homeVC, animated: true, completion: nil)
-//        } else if(item.tag == 1) {
-//            let editVC = storyboard?.instantiateViewController(withIdentifier: "EditViewController") as! EditViewController
-//            editVC.modalPresentationStyle = .fullScreen
-//            self.present(editVC, animated: true, completion: nil)
-//        } else if(item.tag == 2) {
-//            let settingVC = storyboard?.instantiateViewController(withIdentifier: "SettingViewController") as! SettingViewController
-//            settingVC.modalPresentationStyle = .fullScreen
-//            self.present(settingVC, animated: true, completion: nil)
-//        }
-//    }
-//
 
 }
 

--- a/ToDoAppEx/ViewController/SearchViewController.swift
+++ b/ToDoAppEx/ViewController/SearchViewController.swift
@@ -6,15 +6,87 @@
 //
 
 import UIKit
+import RealmSwift
 
 class SearchViewController: UIViewController {
-
     @IBOutlet weak var shareButton: UIBarButtonItem!
+    // 検索結果を表示するtableView
+    @IBOutlet weak var tableView: UITableView!
+    // 現在表示される内容となるリスト
+    private var todoList: Results<TodoItem>!
+    private var token: NotificationToken?
+
     override func viewDidLoad() {
         super.viewDidLoad()
         shareButton.tintColor = UIColor.clear
+
+        // 現在登録されているタスクの一覧を取得
+        setTodoListConfig()
+
+        // TableViewの設定メソッド
+        setTableViewConfig()
     }
 
+    deinit {
+        if let token = self.token {
+            token.invalidate()
+        }
+    }
+}
+
+extension SearchViewController {
+    private func setTodoListConfig() {
+        todoList = RealmManager.shared.getItemInRealm(type: TodoItem.self)
+        token = todoList.observe { [weak self] _ in
+          self?.reload()
+        }
+    }
+
+    private func setTableViewConfig() {
+        tableView.dataSource = self
+        tableView.delegate = self
+
+        tableView.register(UINib(nibName: "ImageCell", bundle: nil), forCellReuseIdentifier: "ImageCell")
+
+        // セルの高さを固定
+        tableView.estimatedRowHeight = 100
+        // 区切り線を左端まで伸ばす
+        tableView.separatorInset = UIEdgeInsets.zero
+        tableView.reloadData()
+    }
+
+    private func reload() {
+        tableView.reloadData()
+    }
+
+    private func changeStatusToDoItem(index: Int) {
+        RealmManager.shared.changeStatusToDoItem(type: TodoItem.self, index: index)
+        reload()
+    }
+}
 
 }
 
+extension SearchViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return todoList.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+
+        let cell = tableView.dequeueReusableCell(withIdentifier: "ImageCell", for: indexPath) as! ImageCell
+        // カスタムセルにRealmの情報を反映
+        cell.configure(image: todoList[indexPath.row].image,
+                       title: todoList[indexPath.row].title,
+                       category: todoList[indexPath.row].category,
+                       startDate: todoList[indexPath.row].startdate,
+                       endDate: todoList[indexPath.row].enddate,
+                       status: todoList[indexPath.row].status)
+        return cell
+    }
+
+    // ToDoのステータス状態を変更するメソッド
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        changeStatusToDoItem(index: indexPath.row)
+    }
+}

--- a/ToDoAppEx/ViewController/SearchViewController.swift
+++ b/ToDoAppEx/ViewController/SearchViewController.swift
@@ -15,6 +15,7 @@ class SearchViewController: UIViewController {
     // 現在表示される内容となるリスト
     private var todoList: Results<TodoItem>!
     private var token: NotificationToken?
+    private var displayList: [TodoItem] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -60,7 +61,7 @@ extension SearchViewController {
     }
 
     private func changeStatusToDoItem(index: Int) {
-        RealmManager.shared.changeStatusToDoItem(type: TodoItem.self, index: index)
+        RealmManager.shared.changeStatusToDoItem(type: TodoItem.self, uuid: displayList[index].itemid)
         reload()
     }
 }


### PR DESCRIPTION
## 変更点
- ホーム画面の表示セルをXibとして再利用可能に変更
- 検索画面を実装
   - 検索画面でホーム画面と同様にセルを表示
   - ToDoのステータスを検索画面でも変更可能
   - 検索窓の入力をもとに表示

## どうやって使うか
- 検索窓に検索ワードを入力
- 検索ワードを入力してキーボードの検索ボタンでフィルタリングされる
- 検索画面でもタスクの完了・未完了を切り替えることができ、ホーム画面にも反映される

## なぜ変更/追加したか
- タスクの検索機能を追加するため

## スクショ(UI変更がある場合)
https://user-images.githubusercontent.com/72324850/185046470-130c28cd-7f27-4ae3-91b3-83486eb8de3f.mp4

## 備考
- todoItemがRealmSwiftに依存しているので、ラッパークラスを用意すると今後においてメリットが多いかもしれません。