### PR TITLE
[fix] 検索画面でカテゴリ選択でも検索条件を変更できるように修正

### DIFF
--- a/ToDoAppEx/Base.lproj/Main.storyboard
+++ b/ToDoAppEx/Base.lproj/Main.storyboard
@@ -433,7 +433,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="100" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="fcG-Zk-y7b">
-                                <rect key="frame" x="0.0" y="188" width="390" height="573"/>
+                                <rect key="frame" x="0.0" y="288" width="390" height="473"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="bezel" placeholder="カテゴリ選択" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0Ua-GF-3wo">
@@ -444,20 +444,69 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
+                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eh8-as-iQU">
+                                <rect key="frame" x="0.0" y="183" width="390" height="100"/>
+                                <subviews>
+                                    <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="P7i-9f-2b0">
+                                        <rect key="frame" x="0.0" y="0.0" width="240" height="101"/>
+                                        <segments>
+                                            <segment title="開始日"/>
+                                            <segment title="完了日"/>
+                                        </segments>
+                                    </segmentedControl>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="bnQ-jT-TwJ">
+                                        <rect key="frame" x="240" y="0.0" width="150" height="100"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="期間" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8iu-HC-D7U">
+                                                <rect key="frame" x="0.0" y="0.0" width="150" height="25"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="ILC-r2-urr">
+                                                <rect key="frame" x="0.0" y="25" width="150" height="25"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="150" id="2jd-s6-Zud"/>
+                                                </constraints>
+                                                <locale key="locale" localeIdentifier="ja_JP"/>
+                                            </datePicker>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="〜" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xU1-XP-mwg">
+                                                <rect key="frame" x="0.0" y="50" width="150" height="25"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="2Pa-2Z-ys4">
+                                                <rect key="frame" x="0.0" y="75" width="150" height="25"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="150" id="wxY-Zc-r1O"/>
+                                                </constraints>
+                                                <locale key="locale" localeIdentifier="ja_JP"/>
+                                            </datePicker>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="100" id="vQk-FE-1f8"/>
+                                </constraints>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="XrZ-ms-aYk"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="xq2-wc-fjW" firstAttribute="trailing" secondItem="XrZ-ms-aYk" secondAttribute="trailing" id="233-Bn-PtB"/>
-                            <constraint firstItem="fcG-Zk-y7b" firstAttribute="top" secondItem="0Ua-GF-3wo" secondAttribute="bottom" constant="10" id="8yW-RX-Snr"/>
                             <constraint firstItem="fcG-Zk-y7b" firstAttribute="leading" secondItem="XrZ-ms-aYk" secondAttribute="leading" id="B6K-0q-yv3"/>
+                            <constraint firstItem="eh8-as-iQU" firstAttribute="leading" secondItem="XrZ-ms-aYk" secondAttribute="leading" id="BGu-g0-wb2"/>
                             <constraint firstItem="xq2-wc-fjW" firstAttribute="leading" secondItem="XrZ-ms-aYk" secondAttribute="leading" id="LdY-bJ-fbe"/>
                             <constraint firstItem="XrZ-ms-aYk" firstAttribute="trailing" secondItem="fcG-Zk-y7b" secondAttribute="trailing" id="cLM-jD-aHc"/>
                             <constraint firstItem="0Ua-GF-3wo" firstAttribute="leading" secondItem="XrZ-ms-aYk" secondAttribute="leading" id="cv0-bS-z5Y"/>
                             <constraint firstItem="XrZ-ms-aYk" firstAttribute="bottom" secondItem="fcG-Zk-y7b" secondAttribute="bottom" id="dMq-bM-0eL"/>
+                            <constraint firstItem="XrZ-ms-aYk" firstAttribute="trailing" secondItem="eh8-as-iQU" secondAttribute="trailing" id="dmL-4Q-dcd"/>
                             <constraint firstItem="0Ua-GF-3wo" firstAttribute="trailing" secondItem="XrZ-ms-aYk" secondAttribute="trailing" id="g1n-CS-LQb"/>
                             <constraint firstItem="xq2-wc-fjW" firstAttribute="top" secondItem="XrZ-ms-aYk" secondAttribute="top" id="nG2-j7-7U2"/>
                             <constraint firstItem="0Ua-GF-3wo" firstAttribute="top" secondItem="xq2-wc-fjW" secondAttribute="bottom" id="pWb-pa-KBn"/>
+                            <constraint firstItem="fcG-Zk-y7b" firstAttribute="top" secondItem="eh8-as-iQU" secondAttribute="bottom" constant="5" id="sfU-4P-eln"/>
+                            <constraint firstItem="eh8-as-iQU" firstAttribute="top" secondItem="0Ua-GF-3wo" secondAttribute="bottom" constant="5" id="xpH-PJ-09R"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Search" id="S8T-II-nY2">
@@ -829,8 +878,8 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="A6y-tQ-PEy"/>
-        <segue reference="6Pt-Io-gzd"/>
+        <segue reference="5wf-5X-na8"/>
+        <segue reference="4H5-DS-sG8"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="Logo-1" width="250" height="174"/>

--- a/ToDoAppEx/Base.lproj/Main.storyboard
+++ b/ToDoAppEx/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xix-qy-TEu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xix-qy-TEu">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="タスクの追加" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eCb-zY-ieL">
-                                <rect key="frame" x="110.00000000000001" y="111" width="170.33333333333337" height="55"/>
+                                <rect key="frame" x="110.00000000000001" y="108" width="170.33333333333337" height="55"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="77y-EN-rIa"/>
                                 </constraints>
@@ -27,7 +27,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="bezel" placeholder="例: 資料整理" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="VZM-lW-ff9">
-                                <rect key="frame" x="95" y="176" width="200" height="30"/>
+                                <rect key="frame" x="95" y="173" width="200" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="ex9-GF-yYL"/>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="mVT-GJ-WNR"/>
@@ -36,7 +36,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="カテゴリの設定" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eSu-fF-eu8">
-                                <rect key="frame" x="110.00000000000001" y="236" width="170.33333333333337" height="55"/>
+                                <rect key="frame" x="110.00000000000001" y="233" width="170.33333333333337" height="55"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="DdD-67-zwV"/>
                                 </constraints>
@@ -45,7 +45,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="bezel" placeholder="例: Work" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xzP-DY-4vV">
-                                <rect key="frame" x="95" y="301" width="200" height="30"/>
+                                <rect key="frame" x="95" y="298" width="200" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="Kha-uU-WkY"/>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="dN1-VQ-S6T"/>
@@ -54,7 +54,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="開始日時" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="POy-PM-Gwi">
-                                <rect key="frame" x="146.33333333333334" y="376" width="97.333333333333343" height="55"/>
+                                <rect key="frame" x="146.33333333333334" y="373" width="97.333333333333343" height="55"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="Lcv-7R-zC4"/>
                                 </constraints>
@@ -63,7 +63,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <datePicker contentMode="center" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="fill" contentVerticalAlignment="fill" datePickerMode="dateAndTime" minuteInterval="1" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="NdB-MM-xel">
-                                <rect key="frame" x="95" y="441" width="200" height="50"/>
+                                <rect key="frame" x="95" y="438" width="200" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="AWJ-la-gNE"/>
                                     <constraint firstAttribute="width" constant="200" id="hlE-1J-egM"/>
@@ -71,7 +71,7 @@
                                 <locale key="locale" localeIdentifier="ja"/>
                             </datePicker>
                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="rzz-uF-xuG">
-                                <rect key="frame" x="95" y="586" width="200" height="50"/>
+                                <rect key="frame" x="95" y="583" width="200" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="4ke-6i-rhw"/>
                                     <constraint firstAttribute="width" constant="200" id="uw8-JT-AlB"/>
@@ -93,7 +93,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="終了日時" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xh5-UD-EjX">
-                                <rect key="frame" x="146.33333333333334" y="521" width="97.333333333333343" height="55"/>
+                                <rect key="frame" x="146.33333333333334" y="518" width="97.333333333333343" height="55"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="rhh-B3-dsL"/>
                                 </constraints>
@@ -160,7 +160,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="2V9-9V-eNJ">
-                                <rect key="frame" x="0.0" y="91" width="390" height="662"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="668"/>
                                 <subviews>
                                     <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="piE-rN-B8r">
                                         <rect key="frame" x="0.0" y="0.0" width="390" height="50"/>
@@ -170,11 +170,11 @@
                                         <textInputTraits key="textInputTraits"/>
                                     </searchBar>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="wAR-gc-HAg">
-                                        <rect key="frame" x="0.0" y="50" width="390" height="542"/>
+                                        <rect key="frame" x="0.0" y="50" width="390" height="548"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="shareAccount" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="shareAccount" id="UeS-eq-sNr" customClass="ShareAccountCell" customModule="ToDoAppEx" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="50" width="390" height="42.666667938232422"/>
+                                                <rect key="frame" x="0.0" y="44.666666030883789" width="390" height="42.666667938232422"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UeS-eq-sNr" id="lJw-GG-M5q">
                                                     <rect key="frame" x="0.0" y="0.0" width="390" height="42.666667938232422"/>
@@ -201,7 +201,7 @@
                                         </prototypes>
                                     </tableView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bcz-53-uRl">
-                                        <rect key="frame" x="0.0" y="592" width="390" height="70"/>
+                                        <rect key="frame" x="0.0" y="598" width="390" height="70"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="70" id="6fp-Ot-lfU"/>
                                         </constraints>
@@ -245,17 +245,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ycG-tx-0wc">
-                                <rect key="frame" x="50" y="147" width="290" height="34"/>
+                                <rect key="frame" x="50" y="144" width="290" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="password confirm" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fxC-Nd-blF">
-                                <rect key="frame" x="50" y="261" width="290" height="34"/>
+                                <rect key="frame" x="50" y="258" width="290" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="c5B-7Z-DkZ">
-                                <rect key="frame" x="110.66666666666669" y="395" width="169" height="30"/>
+                                <rect key="frame" x="110.66666666666669" y="392" width="169" height="30"/>
                                 <color key="backgroundColor" systemColor="linkColor"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="パスワードを設定する">
@@ -266,7 +266,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nn6-5V-XTt">
-                                <rect key="frame" x="110.66666666666669" y="505" width="169" height="30"/>
+                                <rect key="frame" x="110.66666666666669" y="502" width="169" height="30"/>
                                 <color key="backgroundColor" systemColor="linkColor"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="パスワードを設定しない">
@@ -277,7 +277,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gFm-Wp-M1x">
-                                <rect key="frame" x="82.333333333333329" y="67" width="225.33333333333337" height="40.666666666666657"/>
+                                <rect key="frame" x="82.333333333333329" y="64" width="225.33333333333337" height="40.666666666666657"/>
                                 <string key="text">パスワードを設定する場合は
 パスワードを入力して下さい</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -322,7 +322,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="9go-nZ-4K1">
-                                <rect key="frame" x="0.0" y="47" width="390" height="750"/>
+                                <rect key="frame" x="0.0" y="44" width="390" height="756"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e5n-lr-hq2">
                                         <rect key="frame" x="0.0" y="0.0" width="390" height="60"/>
@@ -364,11 +364,11 @@
                                         </constraints>
                                     </stackView>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="l57-As-sk3">
-                                        <rect key="frame" x="0.0" y="120" width="390" height="630"/>
+                                        <rect key="frame" x="0.0" y="120" width="390" height="636"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="shareTodoItem" id="liX-Qn-a8R" customClass="ShareTodoItemCell" customModule="ToDoAppEx" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="50" width="390" height="40.666667938232422"/>
+                                                <rect key="frame" x="0.0" y="44.666666030883789" width="390" height="40.666667938232422"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="liX-Qn-a8R" id="PQP-Pu-qdb">
                                                     <rect key="frame" x="0.0" y="0.0" width="390" height="40.666667938232422"/>
@@ -426,33 +426,45 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="xq2-wc-fjW">
-                                <rect key="frame" x="0.0" y="91" width="390" height="50"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="ldr-BS-AFe"/>
                                 </constraints>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="100" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="fcG-Zk-y7b">
-                                <rect key="frame" x="0.0" y="141" width="390" height="620"/>
+                                <rect key="frame" x="0.0" y="188" width="390" height="573"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="bezel" placeholder="カテゴリ選択" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0Ua-GF-3wo">
+                                <rect key="frame" x="0.0" y="138" width="390" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="75Z-La-uo1"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="XrZ-ms-aYk"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="xq2-wc-fjW" firstAttribute="trailing" secondItem="XrZ-ms-aYk" secondAttribute="trailing" id="233-Bn-PtB"/>
+                            <constraint firstItem="fcG-Zk-y7b" firstAttribute="top" secondItem="0Ua-GF-3wo" secondAttribute="bottom" constant="10" id="8yW-RX-Snr"/>
                             <constraint firstItem="fcG-Zk-y7b" firstAttribute="leading" secondItem="XrZ-ms-aYk" secondAttribute="leading" id="B6K-0q-yv3"/>
                             <constraint firstItem="xq2-wc-fjW" firstAttribute="leading" secondItem="XrZ-ms-aYk" secondAttribute="leading" id="LdY-bJ-fbe"/>
                             <constraint firstItem="XrZ-ms-aYk" firstAttribute="trailing" secondItem="fcG-Zk-y7b" secondAttribute="trailing" id="cLM-jD-aHc"/>
+                            <constraint firstItem="0Ua-GF-3wo" firstAttribute="leading" secondItem="XrZ-ms-aYk" secondAttribute="leading" id="cv0-bS-z5Y"/>
                             <constraint firstItem="XrZ-ms-aYk" firstAttribute="bottom" secondItem="fcG-Zk-y7b" secondAttribute="bottom" id="dMq-bM-0eL"/>
-                            <constraint firstItem="fcG-Zk-y7b" firstAttribute="top" secondItem="xq2-wc-fjW" secondAttribute="bottom" id="kee-Rz-Mlp"/>
+                            <constraint firstItem="0Ua-GF-3wo" firstAttribute="trailing" secondItem="XrZ-ms-aYk" secondAttribute="trailing" id="g1n-CS-LQb"/>
                             <constraint firstItem="xq2-wc-fjW" firstAttribute="top" secondItem="XrZ-ms-aYk" secondAttribute="top" id="nG2-j7-7U2"/>
+                            <constraint firstItem="0Ua-GF-3wo" firstAttribute="top" secondItem="xq2-wc-fjW" secondAttribute="bottom" id="pWb-pa-KBn"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Search" id="S8T-II-nY2">
                         <barButtonItem key="rightBarButtonItem" title="Item" image="cloud" catalog="system" id="sEz-ds-nV0"/>
                     </navigationItem>
                     <connections>
+                        <outlet property="categoryTextField" destination="0Ua-GF-3wo" id="5PM-wW-mDc"/>
                         <outlet property="searchBar" destination="xq2-wc-fjW" id="Zr5-Cw-OJs"/>
                         <outlet property="shareButton" destination="sEz-ds-nV0" id="Akl-kI-1wb"/>
                         <outlet property="tableView" destination="fcG-Zk-y7b" id="QVA-qD-mMv"/>
@@ -460,7 +472,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CZE-Mh-WBF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1849" y="443"/>
+            <point key="canvasLocation" x="1847.6923076923076" y="442.89099526066349"/>
         </scene>
         <!--Login View Controller-->
         <scene sceneID="KRv-Kd-NAM">
@@ -471,7 +483,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ugS-BA-zlp">
-                                <rect key="frame" x="20" y="87" width="350" height="580"/>
+                                <rect key="frame" x="20" y="84" width="350" height="580"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo-1" translatesAutoresizingMaskIntoConstraints="NO" id="O9S-Vq-Vg9">
                                         <rect key="frame" x="0.0" y="0.0" width="350" height="280"/>
@@ -539,7 +551,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="aTg-zz-Tdp">
-                                <rect key="frame" x="20" y="87" width="350" height="580"/>
+                                <rect key="frame" x="20" y="84" width="350" height="580"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo-1" translatesAutoresizingMaskIntoConstraints="NO" id="5O2-zj-eCH">
                                         <rect key="frame" x="0.0" y="0.0" width="350" height="280"/>
@@ -586,7 +598,7 @@
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ERH-Wb-fiI">
-                                <rect key="frame" x="176" y="707" width="38" height="30"/>
+                                <rect key="frame" x="176" y="704" width="38" height="30"/>
                                 <state key="normal" title="Login"/>
                                 <connections>
                                     <action selector="tappedLoginButton:" destination="xix-qy-TEu" eventType="touchUpInside" id="cZb-9R-vYu"/>
@@ -644,7 +656,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="100" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="648-kV-2vW">
-                                <rect key="frame" x="0.0" y="91" width="390" height="670"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="673"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                         </subviews>
@@ -684,7 +696,7 @@
                     <tabBarItem key="tabBarItem" title="" image="square.and.pencil" catalog="system" id="Q6b-ba-und"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="6zU-zL-j2r">
-                        <rect key="frame" x="0.0" y="47" width="390" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -705,11 +717,11 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="9zu-Wx-jv2">
-                                <rect key="frame" x="0.0" y="91" width="390" height="670"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="673"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingCell" id="ODP-zi-EFd" customClass="SettingCell" customModule="ToDoAppEx" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="390" height="43.666667938232422"/>
+                                        <rect key="frame" x="0.0" y="44.666666030883789" width="390" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ODP-zi-EFd" id="i3z-cU-uSr">
                                             <rect key="frame" x="0.0" y="0.0" width="390" height="43.666667938232422"/>
@@ -784,7 +796,7 @@
                     <tabBarItem key="tabBarItem" title="" image="house.fill" catalog="system" id="4nn-Ru-HNj"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="k3L-aH-iyz">
-                        <rect key="frame" x="0.0" y="47" width="390" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -803,7 +815,7 @@
                     <tabBarItem key="tabBarItem" title="" image="gearshape" catalog="system" id="ALO-a5-afl"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="B6q-eh-b4Y">
-                        <rect key="frame" x="0.0" y="47" width="390" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -822,11 +834,11 @@
     </inferredMetricsTieBreakers>
     <resources>
         <image name="Logo-1" width="250" height="174"/>
-        <image name="cloud" catalog="system" width="128" height="87"/>
-        <image name="gearshape" catalog="system" width="128" height="123"/>
-        <image name="house.fill" catalog="system" width="128" height="104"/>
-        <image name="magnifyingglass" catalog="system" width="128" height="117"/>
-        <image name="square.and.pencil" catalog="system" width="128" height="113"/>
+        <image name="cloud" catalog="system" width="128" height="88"/>
+        <image name="gearshape" catalog="system" width="128" height="121"/>
+        <image name="house.fill" catalog="system" width="128" height="106"/>
+        <image name="magnifyingglass" catalog="system" width="128" height="115"/>
+        <image name="square.and.pencil" catalog="system" width="128" height="115"/>
         <systemColor name="linkColor">
             <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/ToDoAppEx/Base.lproj/Main.storyboard
+++ b/ToDoAppEx/Base.lproj/Main.storyboard
@@ -513,7 +513,10 @@
                         <barButtonItem key="rightBarButtonItem" title="Item" image="cloud" catalog="system" id="sEz-ds-nV0"/>
                     </navigationItem>
                     <connections>
+                        <outlet property="beginDatePicker" destination="ILC-r2-urr" id="t6K-9d-RI3"/>
                         <outlet property="categoryTextField" destination="0Ua-GF-3wo" id="5PM-wW-mDc"/>
+                        <outlet property="dateTypeSegmentedControl" destination="P7i-9f-2b0" id="p8T-rg-Lhg"/>
+                        <outlet property="endDatePicker" destination="2Pa-2Z-ys4" id="wcc-3I-a4h"/>
                         <outlet property="searchBar" destination="xq2-wc-fjW" id="Zr5-Cw-OJs"/>
                         <outlet property="shareButton" destination="sEz-ds-nV0" id="Akl-kI-1wb"/>
                         <outlet property="tableView" destination="fcG-Zk-y7b" id="QVA-qD-mMv"/>

--- a/ToDoAppEx/View/ImageCell.xib
+++ b/ToDoAppEx/View/ImageCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -26,29 +26,32 @@
                             </constraints>
                         </imageView>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6tf-DG-0bb" userLabel="Title StackView">
-                            <rect key="frame" x="144" y="10" width="141.5" height="80"/>
+                            <rect key="frame" x="145" y="10" width="140" height="80"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="xY6-V6-J03">
-                                    <rect key="frame" x="0.0" y="0.0" width="141.5" height="56"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xY6-V6-J03">
+                                    <rect key="frame" x="0.0" y="0.0" width="140" height="56"/>
                                     <attributedString key="attributedText">
                                         <fragment content="タイトル">
                                             <attributes>
-                                                <font key="NSFont" metaFont="system" size="35"/>
+                                                <font key="NSFont" size="35" name=".HiraKakuInterface-W3"/>
                                                 <font key="NSOriginalFont" metaFont="system" size="35"/>
+                                                <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                             </attributes>
                                         </fragment>
                                     </attributedString>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="ybp-Gz-gZV">
-                                    <rect key="frame" x="0.0" y="56" width="141.5" height="24"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ybp-Gz-gZV">
+                                    <rect key="frame" x="0.0" y="56" width="140" height="24"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="24" id="rdb-ww-beE"/>
                                     </constraints>
                                     <attributedString key="attributedText">
                                         <fragment content="ジャンル">
                                             <attributes>
-                                                <font key="NSFont" metaFont="system" size="20"/>
+                                                <color key="NSColor" red="0.16087335350000001" green="0.16432648899999999" blue="0.18431669470000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <font key="NSFont" size="20" name="HiraMaruProN-W4"/>
+                                                <paragraphStyle key="NSParagraphStyle" alignment="right" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                             </attributes>
                                         </fragment>
                                     </attributedString>

--- a/ToDoAppEx/ViewController/SearchViewController.swift
+++ b/ToDoAppEx/ViewController/SearchViewController.swift
@@ -10,13 +10,13 @@ import RealmSwift
 
 class SearchViewController: UIViewController {
     @IBOutlet weak var shareButton: UIBarButtonItem!
-    // 検索結果を表示するtableView
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var searchBar: UISearchBar!
     @IBOutlet weak var categoryTextField: UITextField!
-    // 現在表示される内容となるリスト
+
     private var todoList: Results<TodoItem>!
     private var token: NotificationToken?
+    // 表示される内容となるリスト
     private var displayList: [TodoItem] = []
     private var categoryList: [String] = []
     private var selectedCategory: String = ""
@@ -70,6 +70,7 @@ extension SearchViewController {
             // カテゴリーリストの中身
             _categoryList.append(item.category)
         }
+        // 重複のないリストとして格納
         categoryList = _categoryList.reduce([], { $0.contains($1) ? $0 : $0 + [$1] })
     }
 


### PR DESCRIPTION
## 変更点
- 検索画面でカテゴリ選択でもフィルタリングできるように修正
- 検索画面で日付選択でもフィルタリングできるように修正

## どうやって使うか
- 検索画面からカテゴリを選択してタスクにフィルタをかけられる
- 検索画面から日付を期間指定することでタスクにフィルタを掛けられる

## なぜ変更/追加したか
- タスクが多くなった際に特定のタスクを見つけやすくするため

## スクショ(UI変更がある場合)

https://user-images.githubusercontent.com/72324850/191895650-ae956605-6b09-440b-a327-8c7f7889195d.mp4

## 備考
- 日付はそれぞれ期間の境界値は含めない期間となっています
   - 例：10/1〜10/5なら10/2, 3, 4がフィルタ後のリストとなります
- 検索画面でタスクのステータスを変更することはできますが、検索内容はリセットされます。