### PR TITLE
初回起動でタスク追加後にタスクのステータスを変更するとアプリクラッシュする問題の解消

### DIFF
--- a/ToDoAppEx/Utils/RealmManager.swift
+++ b/ToDoAppEx/Utils/RealmManager.swift
@@ -14,11 +14,11 @@ final class RealmManager {
     // シングルトンとして使用
     public static let shared = RealmManager()
 
-    private var realm: Realm
-
-    private init() {
-        realm = try! Realm()
+    private var realm: Realm {
+        try! Realm()
     }
+
+    private init() {}
 
     /// Realmからデータを取得する
     ///


### PR DESCRIPTION
## 変更点
### バグ原因（仮説レベル、確信なし）
- RealmManagerでrealmプロパティをインスタンス時のみ初期化していたため
- アカウント新規作成でUser型データとしてRealmに追加する時と、その後にToDoItem型データとして追加した時とでおそらくスレッドが異なっている
- そのため、RealmManagerではRealmプロパティとしてインスタンスが使い回されており、スレッドセーフでない処理とみなされていた

### 解決策
- RealmManagerのrealmプロパティをコンピューティッドプロパティとして、常にインスタンスを更新するように修正

## どうやって使うか

## なぜ変更/追加したか

## スクショ(UI変更がある場合)

## 備考
