### PR TITLE
【MVVM】サインアップ画面への適用

### DIFF
--- a/ToDoAppEx.xcodeproj/project.pbxproj
+++ b/ToDoAppEx.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		9F9647E128756EF100B7244E /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9647E028756EF100B7244E /* String+Extension.swift */; };
 		9FA692BB285B48300066850F /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA692BA285B48300066850F /* RealmManager.swift */; };
 		9FB3A5A1290D54A200B4B849 /* SignUpModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB3A5A0290D54A200B4B849 /* SignUpModel.swift */; };
+		9FB3A5A4290E1A7C00B4B849 /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB3A5A3290E1A7C00B4B849 /* SignUpViewModel.swift */; };
 		A0FCB734FFBD16DCABD42CFE /* Pods_ToDoAppExTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3C4A4A23D159A521BF73F0E /* Pods_ToDoAppExTests.framework */; };
 		F421746426AB9B5000B133F1 /* ServerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F421746326AB9B5000B133F1 /* ServerRequest.swift */; };
 		F421746626ABAC2500B133F1 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F421746526ABAC2500B133F1 /* Date+Extension.swift */; };
@@ -77,6 +78,7 @@
 		9F9647E028756EF100B7244E /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		9FA692BA285B48300066850F /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
 		9FB3A5A0290D54A200B4B849 /* SignUpModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpModel.swift; sourceTree = "<group>"; };
+		9FB3A5A3290E1A7C00B4B849 /* SignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewModel.swift; sourceTree = "<group>"; };
 		A1895C9BD803A6D3D6D5D757 /* Pods-ToDoAppEx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ToDoAppEx.release.xcconfig"; path = "Target Support Files/Pods-ToDoAppEx/Pods-ToDoAppEx.release.xcconfig"; sourceTree = "<group>"; };
 		B589D8C785E573BB12FBFB59 /* Pods-ToDoAppEx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ToDoAppEx.debug.xcconfig"; path = "Target Support Files/Pods-ToDoAppEx/Pods-ToDoAppEx.debug.xcconfig"; sourceTree = "<group>"; };
 		BBD0896660E6E0BD1A1F8FA7 /* Pods_ToDoAppEx_ToDoAppExUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ToDoAppEx_ToDoAppExUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -237,6 +239,14 @@
 			path = API;
 			sourceTree = "<group>";
 		};
+		9FB3A5A2290D581900B4B849 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				9FB3A5A3290E1A7C00B4B849 /* SignUpViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		F48F3AC925F3D8E8001E5342 = {
 			isa = PBXGroup;
 			children = (
@@ -266,6 +276,7 @@
 				9FA2208227ADF15500CFD239 /* Utils */,
 				9FA2208027ADE95400CFD239 /* ViewController */,
 				9FA2207F27ADE90300CFD239 /* View */,
+				9FB3A5A2290D581900B4B849 /* ViewModel */,
 				9F5F49912605826E000C2E0A /* Model */,
 				F48F3AD525F3D8E8001E5342 /* AppDelegate.swift */,
 				F48F3AD725F3D8E8001E5342 /* SceneDelegate.swift */,
@@ -544,6 +555,7 @@
 				9FB3A5A1290D54A200B4B849 /* SignUpModel.swift in Sources */,
 				F47286092622CC6F002D6F86 /* SignupViewController.swift in Sources */,
 				9F5F49BC26094FAA000C2E0A /* ImageCell.swift in Sources */,
+				9FB3A5A4290E1A7C00B4B849 /* SignUpViewModel.swift in Sources */,
 				F4F008F527C571D500B44B80 /* AskPasswordSettingViewController.swift in Sources */,
 				9FA692BB285B48300066850F /* RealmManager.swift in Sources */,
 				F4E7B07F28D8130E008E0A92 /* SettingLabelCell.swift in Sources */,

--- a/ToDoAppEx.xcodeproj/project.pbxproj
+++ b/ToDoAppEx.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		9F6384C626460BCA001DFEBD /* CustomView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9F6384C526460BCA001DFEBD /* CustomView.xib */; };
 		9F9647E128756EF100B7244E /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9647E028756EF100B7244E /* String+Extension.swift */; };
 		9FA692BB285B48300066850F /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA692BA285B48300066850F /* RealmManager.swift */; };
+		9FB3A5A1290D54A200B4B849 /* SignUpModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB3A5A0290D54A200B4B849 /* SignUpModel.swift */; };
 		A0FCB734FFBD16DCABD42CFE /* Pods_ToDoAppExTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3C4A4A23D159A521BF73F0E /* Pods_ToDoAppExTests.framework */; };
 		F421746426AB9B5000B133F1 /* ServerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F421746326AB9B5000B133F1 /* ServerRequest.swift */; };
 		F421746626ABAC2500B133F1 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F421746526ABAC2500B133F1 /* Date+Extension.swift */; };
@@ -75,6 +76,7 @@
 		9F6384C526460BCA001DFEBD /* CustomView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomView.xib; sourceTree = "<group>"; };
 		9F9647E028756EF100B7244E /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		9FA692BA285B48300066850F /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
+		9FB3A5A0290D54A200B4B849 /* SignUpModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpModel.swift; sourceTree = "<group>"; };
 		A1895C9BD803A6D3D6D5D757 /* Pods-ToDoAppEx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ToDoAppEx.release.xcconfig"; path = "Target Support Files/Pods-ToDoAppEx/Pods-ToDoAppEx.release.xcconfig"; sourceTree = "<group>"; };
 		B589D8C785E573BB12FBFB59 /* Pods-ToDoAppEx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ToDoAppEx.debug.xcconfig"; path = "Target Support Files/Pods-ToDoAppEx/Pods-ToDoAppEx.debug.xcconfig"; sourceTree = "<group>"; };
 		BBD0896660E6E0BD1A1F8FA7 /* Pods_ToDoAppEx_ToDoAppExUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ToDoAppEx_ToDoAppExUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -175,6 +177,7 @@
 			children = (
 				9F5F499226058303000C2E0A /* TodoItem.swift */,
 				F44C387D26A67C8400D41ED7 /* User.swift */,
+				9FB3A5A0290D54A200B4B849 /* SignUpModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -538,6 +541,7 @@
 				F48F3B1325F447C8001E5342 /* ShareViewController.swift in Sources */,
 				F4E7B07728D7E2F6008E0A92 /* SettingTitleCell.swift in Sources */,
 				F48F3B1825F447D8001E5342 /* SearchViewController.swift in Sources */,
+				9FB3A5A1290D54A200B4B849 /* SignUpModel.swift in Sources */,
 				F47286092622CC6F002D6F86 /* SignupViewController.swift in Sources */,
 				9F5F49BC26094FAA000C2E0A /* ImageCell.swift in Sources */,
 				F4F008F527C571D500B44B80 /* AskPasswordSettingViewController.swift in Sources */,

--- a/ToDoAppEx.xcodeproj/project.pbxproj
+++ b/ToDoAppEx.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		F421746626ABAC2500B133F1 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F421746526ABAC2500B133F1 /* Date+Extension.swift */; };
 		F44C387E26A67C8400D41ED7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44C387D26A67C8400D41ED7 /* User.swift */; };
 		F47286042622C4EA002D6F86 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47286032622C4EA002D6F86 /* LoginViewController.swift */; };
-		F47286092622CC6F002D6F86 /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47286082622CC6F002D6F86 /* SignupViewController.swift */; };
+		F47286092622CC6F002D6F86 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47286082622CC6F002D6F86 /* SignUpViewController.swift */; };
 		F48F3AD625F3D8E8001E5342 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48F3AD525F3D8E8001E5342 /* AppDelegate.swift */; };
 		F48F3AD825F3D8E8001E5342 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48F3AD725F3D8E8001E5342 /* SceneDelegate.swift */; };
 		F48F3ADA25F3D8E8001E5342 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48F3AD925F3D8E8001E5342 /* HomeViewController.swift */; };
@@ -88,7 +88,7 @@
 		F421746526ABAC2500B133F1 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		F44C387D26A67C8400D41ED7 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		F47286032622C4EA002D6F86 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
-		F47286082622CC6F002D6F86 /* SignupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupViewController.swift; sourceTree = "<group>"; };
+		F47286082622CC6F002D6F86 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		F48F3AD225F3D8E8001E5342 /* ToDoAppEx.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ToDoAppEx.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F48F3AD525F3D8E8001E5342 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F48F3AD725F3D8E8001E5342 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -214,7 +214,7 @@
 				F48F3B1225F447C8001E5342 /* ShareViewController.swift */,
 				F48F3B1725F447D8001E5342 /* SearchViewController.swift */,
 				F47286032622C4EA002D6F86 /* LoginViewController.swift */,
-				F47286082622CC6F002D6F86 /* SignupViewController.swift */,
+				F47286082622CC6F002D6F86 /* SignUpViewController.swift */,
 				F4FC9319277CF43B001B9A36 /* ShareTodoItemListViewController.swift */,
 				F4F008F427C571D500B44B80 /* AskPasswordSettingViewController.swift */,
 			);
@@ -553,7 +553,7 @@
 				F4E7B07728D7E2F6008E0A92 /* SettingTitleCell.swift in Sources */,
 				F48F3B1825F447D8001E5342 /* SearchViewController.swift in Sources */,
 				9FB3A5A1290D54A200B4B849 /* SignUpModel.swift in Sources */,
-				F47286092622CC6F002D6F86 /* SignupViewController.swift in Sources */,
+				F47286092622CC6F002D6F86 /* SignUpViewController.swift in Sources */,
 				9F5F49BC26094FAA000C2E0A /* ImageCell.swift in Sources */,
 				9FB3A5A4290E1A7C00B4B849 /* SignUpViewModel.swift in Sources */,
 				F4F008F527C571D500B44B80 /* AskPasswordSettingViewController.swift in Sources */,

--- a/ToDoAppEx/API/ServerRequest.swift
+++ b/ToDoAppEx/API/ServerRequest.swift
@@ -8,23 +8,22 @@
 import Foundation
 
 class ServerRequest {
-    func sendServerRequest(urlString: String, params: [String:Any], completion: @escaping (_: Data) -> Void){
+    func sendServerRequest(urlString: String, params: [String:Any], completion: @escaping (_: Data?) -> Void) {
         let request = NSMutableURLRequest(url: URL(string: urlString)!)
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         do{
             request.httpBody = try JSONSerialization.data(withJSONObject: params, options: .prettyPrinted)
-            let task:URLSessionDataTask = URLSession.shared.dataTask(with: request as URLRequest, completionHandler: {(data,response,error) -> Void in
+            let task:URLSessionDataTask = URLSession.shared.dataTask(with: request as URLRequest, completionHandler: {(data, response, error) -> Void in
                 if error == nil {
                     print("server response: \(String(describing: response))")
-                    completion(data!)
+                    completion(data)
                 } else {
                     print("server error:\(String(describing:error))")
-                    return
                 }
             })
             task.resume()
-        }catch{
+        } catch {
             print("error:\(error)")
         }
     }

--- a/ToDoAppEx/Base.lproj/Main.storyboard
+++ b/ToDoAppEx/Base.lproj/Main.storyboard
@@ -626,22 +626,28 @@
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bbp-bM-3Qe">
-                                                <rect key="frame" x="0.0" y="48.666666666666686" width="350" height="34"/>
+                                                <rect key="frame" x="0.0" y="39" width="350" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="56S-88-dGg">
-                                                <rect key="frame" x="0.0" y="97.666666666666686" width="350" height="34"/>
+                                                <rect key="frame" x="0.0" y="78" width="350" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="password confirm" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WbH-Qc-jhg">
-                                                <rect key="frame" x="0.0" y="146.33333333333337" width="350" height="34"/>
+                                                <rect key="frame" x="0.0" y="117" width="350" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OQi-c0-y3p">
+                                                <rect key="frame" x="0.0" y="156" width="350" height="44"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uUI-Q9-ua7">
-                                                <rect key="frame" x="0.0" y="195.33333333333337" width="350" height="40"/>
+                                                <rect key="frame" x="0.0" y="205" width="350" height="40"/>
                                                 <color key="backgroundColor" systemColor="systemGreenColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="40" id="gIb-bO-5T7"/>
@@ -677,9 +683,11 @@
                     </view>
                     <connections>
                         <outlet property="confirmPassword" destination="WbH-Qc-jhg" id="O9A-oH-UvP"/>
+                        <outlet property="createAccountButton" destination="uUI-Q9-ua7" id="r6G-BA-RFD"/>
                         <outlet property="displayName" destination="XTT-tc-J8B" id="Ob1-He-QTd"/>
                         <outlet property="email" destination="bbp-bM-3Qe" id="St4-Dx-3Fm"/>
                         <outlet property="password" destination="56S-88-dGg" id="SNX-zb-Zad"/>
+                        <outlet property="validationCheckLabel" destination="OQi-c0-y3p" id="ZJm-P5-lbY"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="uPE-6W-qul" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/ToDoAppEx/Base.lproj/Main.storyboard
+++ b/ToDoAppEx/Base.lproj/Main.storyboard
@@ -600,10 +600,10 @@
             </objects>
             <point key="canvasLocation" x="-1674" y="106"/>
         </scene>
-        <!--Signup View Controller-->
+        <!--Sign Up View Controller-->
         <scene sceneID="LCY-SW-LzD">
             <objects>
-                <viewController storyboardIdentifier="SignupViewController" id="xix-qy-TEu" customClass="SignupViewController" customModule="ToDoAppEx" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SignupViewController" id="xix-qy-TEu" customClass="SignUpViewController" customModule="ToDoAppEx" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="QRH-vW-UVg">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/ToDoAppEx/Model/SignUpModel.swift
+++ b/ToDoAppEx/Model/SignUpModel.swift
@@ -20,13 +20,18 @@ enum SignUpModelError: Error {
 }
 
 protocol SignUpModelProtocol {
-    func validate(email: String, password: String,
-                  confirmPassword: String, displayName: String) -> Result<Void>
+    func validate(email: String?, password: String?,
+                  confirmPassword: String?, displayName: String?) -> Result<Void>
 }
 
 final class SignUpModel: SignUpModelProtocol {
-    func validate(email: String, password: String,
-                  confirmPassword: String, displayName: String) -> Result<Void> {
+    func validate(email: String?, password: String?,
+                  confirmPassword: String?, displayName: String?) -> Result<Void> {
+        guard let email = email, let password = password,
+              let confirmPassword = confirmPassword, let displayName = displayName else {
+                  return .failure(SignUpModelError.emptyField)
+              }
+
         // いずれかの入力がない場合は全て.emptyFieldを返す
         guard !email.isEmpty, !password.isEmpty, !confirmPassword.isEmpty, !displayName.isEmpty else {
             return .failure(SignUpModelError.emptyField)
@@ -34,7 +39,7 @@ final class SignUpModel: SignUpModelProtocol {
 
         if confirmPassword != password {
             return .failure(SignUpModelError.differentConfirmPassword)
-        } else if email.contains("@") {
+        } else if !email.contains("@") {
             return .failure(SignUpModelError.invalidMailAddress)
         } else {
             return .success(())

--- a/ToDoAppEx/Model/SignUpModel.swift
+++ b/ToDoAppEx/Model/SignUpModel.swift
@@ -6,3 +6,38 @@
 //
 
 import Foundation
+
+enum Result<T> {
+    case success(T)
+    case failure(Error)
+}
+
+enum SignUpModelError: Error {
+    case invalidMailAddress
+    case differentConfirmPassword
+    case emptyField
+    case other
+}
+
+protocol SignUpModelProtocol {
+    func validate(email: String, password: String,
+                  confirmPassword: String, displayName: String) -> Result<Void>
+}
+
+final class SignUpModel: SignUpModelProtocol {
+    func validate(email: String, password: String,
+                  confirmPassword: String, displayName: String) -> Result<Void> {
+        // いずれかの入力がない場合は全て.emptyFieldを返す
+        guard !email.isEmpty, !password.isEmpty, !confirmPassword.isEmpty, !displayName.isEmpty else {
+            return .failure(SignUpModelError.emptyField)
+        }
+
+        if confirmPassword != password {
+            return .failure(SignUpModelError.differentConfirmPassword)
+        } else if email.contains("@") {
+            return .failure(SignUpModelError.invalidMailAddress)
+        } else {
+            return .success(())
+        }
+    }
+}

--- a/ToDoAppEx/Model/SignUpModel.swift
+++ b/ToDoAppEx/Model/SignUpModel.swift
@@ -1,0 +1,8 @@
+//
+//  SignUpModel.swift
+//  ToDoAppEx
+//
+//  Created by Naoyuki Kan on 2022/10/29.
+//
+
+import Foundation

--- a/ToDoAppEx/Model/SignUpModel.swift
+++ b/ToDoAppEx/Model/SignUpModel.swift
@@ -16,12 +16,15 @@ enum SignUpModelError: Error {
     case invalidMailAddress
     case differentConfirmPassword
     case emptyField
+    case serverError
+    case jsonDecord
     case other
 }
 
 protocol SignUpModelProtocol {
     func validate(email: String?, password: String?,
                   confirmPassword: String?, displayName: String?) -> Result<Void>
+    func createAccount(email: String?, password: String?, displayName: String?, completion: @escaping (Result<Void>) -> Void)
 }
 
 final class SignUpModel: SignUpModelProtocol {
@@ -44,5 +47,67 @@ final class SignUpModel: SignUpModelProtocol {
         } else {
             return .success(())
         }
+    }
+
+    /// アカウント作成をサーバーに要求
+    /// - Parameters:
+    ///   - email: メールアドレス
+    ///   - password: アカウントのパスワード
+    ///   - displayName: アカウント名
+    ///   - completion: アカウント作成完了後に呼び出されるコールバック
+    ///
+    ///  protocolではデフォルト引数が指定できないため再度呼び出して、共有機能のデフォルトでの値を指定している
+    func createAccount(email: String?, password: String?, displayName: String?, completion: @escaping (Result<Void>) -> Void) {
+        createAccount(email: email, password: password, displayName: displayName, isPublic: false, sharePassword: "", completion: completion)
+    }
+
+    private func createAccount(email: String?, password: String?, displayName: String?, isPublic: Bool, sharePassword: String, completion: @escaping (Result<Void>) -> Void) {
+        guard let email = email, let password = password,
+              let displayName = displayName else {
+            // アカウント作成ボタン押下時にいずれかがnullの場合には実装の仕様違い
+            fatalError()
+        }
+
+        let serverRequest: ServerRequest = ServerRequest()
+        serverRequest.sendServerRequest(
+            urlString: "http://tk2-235-27465.vs.sakura.ne.jp/insert_account",
+            params: [
+                "accountname": displayName,
+                "password": password,
+                "email": email,
+                "publicprivate": isPublic,
+                "sharepassword": sharePassword
+            ]) { data in
+                guard let data = data else {
+                    print("server error")
+                    completion(.failure(SignUpModelError.serverError))
+                    return
+                }
+                do {
+                    let json = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments)
+                    guard let doc = json as? NSDictionary else {
+                        completion(.failure(SignUpModelError.jsonDecord))
+                        return
+                    }
+                    self.writeUserInfo(doc: doc)
+                    completion(.success(()))
+                } catch {
+                    print("json decord error")
+                    completion(.failure(SignUpModelError.jsonDecord))
+                    return
+                }
+            }
+    }
+
+    func writeUserInfo(doc: NSDictionary) {
+        let user = User()
+        user.userid = doc["_id"] as! String
+        user.accountname = doc["accountname"] as! String
+        user.password = doc["password"] as! String
+        user.email = doc["email"] as! String
+        user.publicprivate = doc["publicprivate"] as! Bool
+        user.sharepassword = doc["sharepassword"] as! String
+
+        RealmManager.shared.writeItem(user)
     }
 }

--- a/ToDoAppEx/ViewController/HomeViewController.swift
+++ b/ToDoAppEx/ViewController/HomeViewController.swift
@@ -70,7 +70,7 @@ extension HomeViewController {
                 "itemid": targetItem.itemid,
                 "userid": targetItem.userid,
             ],
-            completion: { (data: Data) -> Void in }
+            completion: { (data: Data?) -> Void in }
         )
     }
 

--- a/ToDoAppEx/ViewController/SignupViewController.swift
+++ b/ToDoAppEx/ViewController/SignupViewController.swift
@@ -14,6 +14,7 @@ class SignupViewController: UIViewController {
     @IBOutlet weak var confirmPassword: UITextField!
     @IBOutlet weak var displayName: UITextField!
     let userDefaults = UserDefaults()
+    @IBOutlet weak var validationCheckLabel: UILabel!
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/ToDoAppEx/ViewController/SignupViewController.swift
+++ b/ToDoAppEx/ViewController/SignupViewController.swift
@@ -47,10 +47,8 @@ class SignUpViewController: UIViewController {
     }
 
     @IBAction private func createAccount(_ sender: Any) {
-        viewModel.createAccount(email: email.text, password: password.text, displayName: displayName.text) {
-            // 成功時のみ実行され、エラーの場合にはNotificationCenter経由で通知される
-            self.goToNext()
-        }
+        viewModel.createAccount(email: email.text, password: password.text,
+                                displayName: displayName.text)
     }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -83,9 +81,14 @@ extension SignUpViewController {
             selector: #selector(updateValidationColor),
             name: viewModel.changeColor,
             object: nil)
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(goToNext),
+            name: viewModel.createAccount,
+            object: nil)
     }
 
-    private func goToNext() {
+    @objc private func goToNext() {
         DispatchQueue.main.async {
             let secondViewController = self.storyboard?.instantiateViewController(withIdentifier: "LoginViewController") as! LoginViewController
             secondViewController.modalPresentationStyle = .fullScreen

--- a/ToDoAppEx/ViewController/SignupViewController.swift
+++ b/ToDoAppEx/ViewController/SignupViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import RealmSwift
 
-class SignupViewController: UIViewController {
+class SignUpViewController: UIViewController {
     @IBOutlet weak var email: UITextField!
     @IBOutlet weak var password: UITextField!
     @IBOutlet weak var confirmPassword: UITextField!

--- a/ToDoAppEx/ViewController/SignupViewController.swift
+++ b/ToDoAppEx/ViewController/SignupViewController.swift
@@ -62,22 +62,12 @@ class SignUpViewController: UIViewController {
 
 extension SignUpViewController {
     private func setUpBinding() {
-        email.addTarget(
-            self,
-            action: #selector(textFieldEditingChanged),
-            for: .editingChanged)
-        password.addTarget(
-            self,
-            action: #selector(textFieldEditingChanged),
-            for: .editingChanged)
-        confirmPassword.addTarget(
-            self,
-            action: #selector(textFieldEditingChanged),
-            for: .editingChanged)
-        displayName.addTarget(
-            self,
-            action: #selector(textFieldEditingChanged),
-            for: .editingChanged)
+        [email, password, confirmPassword, displayName].forEach { $0.addTarget(
+                self,
+                action: #selector(textFieldEditingChanged),
+                for: .editingChanged)
+        }
+
         notificationCenter.addObserver(
             self,
             selector: #selector(updateValidationText),

--- a/ToDoAppEx/ViewController/SignupViewController.swift
+++ b/ToDoAppEx/ViewController/SignupViewController.swift
@@ -47,21 +47,9 @@ class SignUpViewController: UIViewController {
     }
 
     @IBAction private func createAccount(_ sender: Any) {
-        if password.text != "" && password.text == confirmPassword.text {
-            let serverRequest: ServerRequest = ServerRequest()
-            serverRequest.sendServerRequest(
-                urlString: "http://tk2-235-27465.vs.sakura.ne.jp/insert_account",
-                params: [
-                    "accountname": self.displayName.text ?? "",
-                    "password": self.password.text ?? "",
-                    "email": self.email.text ?? "",
-                    "publicprivate": false,
-                    "sharepassword": ""
-                ],
-                completion: self.goToNext(data:))
-
-        } else {
-            email.text = "error!"
+        viewModel.createAccount(email: email.text, password: password.text, displayName: displayName.text) {
+            // 成功時のみ実行され、エラーの場合にはNotificationCenter経由で通知される
+            self.goToNext()
         }
     }
 
@@ -107,30 +95,13 @@ extension SignUpViewController {
             object: nil)
     }
 
-    private func goToNext(data: Data?) {
-
-        do {
-            let json = try JSONSerialization.jsonObject(with: data!, options: JSONSerialization.ReadingOptions.allowFragments)
-            let doc = json as! NSDictionary
-            let user = User()
-            user.userid = doc["_id"] as! String
-            user.accountname = doc["accountname"] as! String
-            user.password = doc["password"] as! String
-            user.email = doc["email"] as! String
-            user.publicprivate = doc["publicprivate"] as! Bool
-            user.sharepassword = doc["sharepassword"] as! String
-            RealmManager.shared.writeItem(user)
-        } catch {
-            print("signup error")
-            return
-        }
+    private func goToNext() {
         DispatchQueue.main.async {
             let secondViewController = self.storyboard?.instantiateViewController(withIdentifier: "LoginViewController") as! LoginViewController
             secondViewController.modalPresentationStyle = .fullScreen
             self.present(secondViewController, animated: true, completion: nil)
         }
     }
-
 }
 
 // MARK: ViewModel Binding

--- a/ToDoAppEx/ViewModel/SignUpViewModel.swift
+++ b/ToDoAppEx/ViewModel/SignUpViewModel.swift
@@ -12,6 +12,7 @@ final class SignUpViewModel {
     let changeText = Notification.Name("changeText")
     let changeColor = Notification.Name("changeColor")
     let activateButton = Notification.Name("activateButton")
+    let createAccount = Notification.Name("createAccount")
 
     private let notificationCenter: NotificationCenter
     private let model: SignUpModelProtocol
@@ -39,15 +40,14 @@ final class SignUpViewModel {
         }
     }
 
-    func createAccount(email: String?, password: String?, displayName: String?, completion:  @escaping () -> Void) {
+    func createAccount(email: String?, password: String?, displayName: String?) {
         model.createAccount(email: email, password: password, displayName: displayName) { result in
             switch result {
             case .success:
-                completion()
+                self.notificationCenter.post(name: self.createAccount, object: nil)
             case .failure(let error as SignUpModelError):
                 self.notificationCenter.post(name: self.changeText, object: error.errorText)
                 self.notificationCenter.post(name: self.changeColor, object: UIColor.red)
-                self.notificationCenter.post(name: self.activateButton, object: false)
             case .failure(_):
                 fatalError("Unexpected pattern.")
             }

--- a/ToDoAppEx/ViewModel/SignUpViewModel.swift
+++ b/ToDoAppEx/ViewModel/SignUpViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  SignUpViewModel.swift
+//  ToDoAppEx
+//
+//  Created by Naoyuki Kan on 2022/10/30.
+//
+
+import Foundation

--- a/ToDoAppEx/ViewModel/SignUpViewModel.swift
+++ b/ToDoAppEx/ViewModel/SignUpViewModel.swift
@@ -6,3 +6,51 @@
 //
 
 import Foundation
+import UIKit
+
+final class SignUpViewModel {
+    let changeText = Notification.Name("changeText")
+    let changeColor = Notification.Name("changeColor")
+    let activateButton = Notification.Name("activateButton")
+
+    private let notificationCenter: NotificationCenter
+    private let model: SignUpModelProtocol
+
+    init(notificationCenter: NotificationCenter, model: SignUpModelProtocol = SignUpModel()) {
+        self.notificationCenter = notificationCenter
+        self.model = model
+    }
+
+    func textFieldChanged(email: String?, password: String?,
+                          confirmPassword: String?, displayName: String?) {
+        let result = model.validate(email: email, password: password, confirmPassword: confirmPassword, displayName: displayName)
+
+        switch result {
+        case .success:
+            notificationCenter.post(name: changeText, object: "OK!!!")
+            notificationCenter.post(name: changeColor, object: UIColor.green)
+            notificationCenter.post(name: activateButton, object: true)
+        case .failure(let error as SignUpModelError):
+            notificationCenter.post(name: changeText, object: error.errorText)
+            notificationCenter.post(name: changeColor, object: UIColor.red)
+            notificationCenter.post(name: activateButton, object: false)
+        case _:
+            fatalError("Unexpected pattern.")
+        }
+    }
+}
+
+extension SignUpModelError {
+    fileprivate var errorText: String {
+        switch self {
+        case .invalidMailAddress:
+            return "有効でないメールアドレスです。"
+        case .differentConfirmPassword:
+            return "パスワードが一致していません。"
+        case .emptyField:
+            return "未入力の項目があります。"
+        case .other:
+            return "不明のエラーです。"
+        }
+    }
+}

--- a/ToDoAppEx/ViewModel/SignUpViewModel.swift
+++ b/ToDoAppEx/ViewModel/SignUpViewModel.swift
@@ -38,6 +38,21 @@ final class SignUpViewModel {
             fatalError("Unexpected pattern.")
         }
     }
+
+    func createAccount(email: String?, password: String?, displayName: String?, completion:  @escaping () -> Void) {
+        model.createAccount(email: email, password: password, displayName: displayName) { result in
+            switch result {
+            case .success:
+                completion()
+            case .failure(let error as SignUpModelError):
+                self.notificationCenter.post(name: self.changeText, object: error.errorText)
+                self.notificationCenter.post(name: self.changeColor, object: UIColor.red)
+                self.notificationCenter.post(name: self.activateButton, object: false)
+            case .failure(_):
+                fatalError("Unexpected pattern.")
+            }
+        }
+    }
 }
 
 extension SignUpModelError {
@@ -49,6 +64,10 @@ extension SignUpModelError {
             return "パスワードが一致していません。"
         case .emptyField:
             return "未入力の項目があります。"
+        case .serverError:
+            return "通信でエラーが発生しました。通信環境をお確かめください。"
+        case .jsonDecord:
+            return "処置中に問題が発生しました。"
         case .other:
             return "不明のエラーです。"
         }

--- a/ToDoAppExTests/ToDoAppExTests.swift
+++ b/ToDoAppExTests/ToDoAppExTests.swift
@@ -23,6 +23,26 @@ class ToDoAppExTests: XCTestCase {
         // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
 
+    func testSignUpModel() {
+        let model = SignUpModel()
+
+        let exp: XCTestExpectation = expectation(description: "戻ってくるまで待つ！")
+
+        model.createAccount(email: "hoge@mail", password: "hoge", displayName: "Hoge") { result in
+            switch result {
+            case .success:
+                XCTAssertTrue(true, "新しいリスト追加に成功")
+            case .failure(let error as SignUpModelError):
+                XCTAssertTrue(false, "エラー：\(error)")
+            case .failure(_):
+                fatalError("Unexpected pattern.")
+            }
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 5)
+    }
+
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {


### PR DESCRIPTION
## 変更点
- サインアップ画面に対してMVVMを適用する
- NotificationCenterでさしあたりバインディングは実装する
- 実装の順序想定
   1.  Modelの追加
   2. ViewModelの追加
   3. （ModelとViewModelの単体テスト追加）
   4. ViewとViewModelの結合

## どうやって使うか

## なぜ変更/追加したか
- チームメンバーのMVVMへの理解を深めるため
- メンバーが今後増えていった時に設計がきっちりとしている方がタスクが割り振りやすい

## スクショ(UI変更がある場合)
https://user-images.githubusercontent.com/72324850/198863299-b94336d9-1146-43d3-9b9c-1a7f202cc69b.mp4


## 備考
- MVVMの設計思想が共有できたあとに、RxSwiftへの移行も視野に入れています