### PR TITLE
[MVVM]ログイン画面への適用

### DIFF
--- a/ToDoAppEx.xcodeproj/project.pbxproj
+++ b/ToDoAppEx.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		47C91966293262930009F2F7 /* LoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C91965293262930009F2F7 /* LoginModel.swift */; };
+		47C91968293304A70009F2F7 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C91967293304A70009F2F7 /* LoginViewModel.swift */; };
 		84342FDA46B03BB410F7DD02 /* Pods_ToDoAppEx.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09C99418B6C2D6AACD60CB37 /* Pods_ToDoAppEx.framework */; };
 		9B9012757307C49A4E96D15A /* Pods_ToDoAppEx_ToDoAppExUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BBD0896660E6E0BD1A1F8FA7 /* Pods_ToDoAppEx_ToDoAppExUITests.framework */; };
 		9F33584928AA406F003A5263 /* ImageCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9F33584828AA406F003A5263 /* ImageCell.xib */; };
@@ -70,6 +72,8 @@
 /* Begin PBXFileReference section */
 		09C99418B6C2D6AACD60CB37 /* Pods_ToDoAppEx.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ToDoAppEx.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E8C201AAE2FAC4C3E510521 /* Pods-ToDoAppEx-ToDoAppExUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ToDoAppEx-ToDoAppExUITests.debug.xcconfig"; path = "Target Support Files/Pods-ToDoAppEx-ToDoAppExUITests/Pods-ToDoAppEx-ToDoAppExUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		47C91965293262930009F2F7 /* LoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginModel.swift; sourceTree = "<group>"; };
+		47C91967293304A70009F2F7 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		9F33584828AA406F003A5263 /* ImageCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ImageCell.xib; sourceTree = "<group>"; };
 		9F5F499226058303000C2E0A /* TodoItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoItem.swift; sourceTree = "<group>"; };
 		9F5F49BB26094FAA000C2E0A /* ImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCell.swift; sourceTree = "<group>"; };
@@ -180,6 +184,7 @@
 				9F5F499226058303000C2E0A /* TodoItem.swift */,
 				F44C387D26A67C8400D41ED7 /* User.swift */,
 				9FB3A5A0290D54A200B4B849 /* SignUpModel.swift */,
+				47C91965293262930009F2F7 /* LoginModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -243,6 +248,7 @@
 			isa = PBXGroup;
 			children = (
 				9FB3A5A3290E1A7C00B4B849 /* SignUpViewModel.swift */,
+				47C91967293304A70009F2F7 /* LoginViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -557,6 +563,7 @@
 				9F5F49BC26094FAA000C2E0A /* ImageCell.swift in Sources */,
 				9FB3A5A4290E1A7C00B4B849 /* SignUpViewModel.swift in Sources */,
 				F4F008F527C571D500B44B80 /* AskPasswordSettingViewController.swift in Sources */,
+				47C91968293304A70009F2F7 /* LoginViewModel.swift in Sources */,
 				9FA692BB285B48300066850F /* RealmManager.swift in Sources */,
 				F4E7B07F28D8130E008E0A92 /* SettingLabelCell.swift in Sources */,
 				F48F3B0E25F447B6001E5342 /* SettingViewController.swift in Sources */,
@@ -572,6 +579,7 @@
 				F48F3AD625F3D8E8001E5342 /* AppDelegate.swift in Sources */,
 				9F5F499326058303000C2E0A /* TodoItem.swift in Sources */,
 				9F6384C126460B93001DFEBD /* CustomView.swift in Sources */,
+				47C91966293262930009F2F7 /* LoginModel.swift in Sources */,
 				F492B7A5263BC62800E2F11D /* TabBarController.swift in Sources */,
 				F421746426AB9B5000B133F1 /* ServerRequest.swift in Sources */,
 				F47286042622C4EA002D6F86 /* LoginViewController.swift in Sources */,
@@ -754,8 +762,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = A98KZDWY2P;
 				CURRENT_PROJECT_VERSION = 4;
+				DEVELOPMENT_TEAM = A98KZDWY2P;
 				INFOPLIST_FILE = ToDoAppEx/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "do22 - To Do List";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
@@ -781,8 +789,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = A98KZDWY2P;
 				CURRENT_PROJECT_VERSION = 4;
+				DEVELOPMENT_TEAM = A98KZDWY2P;
 				INFOPLIST_FILE = ToDoAppEx/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "do22 - To Do List";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.2;

--- a/ToDoAppEx.xcodeproj/project.pbxproj
+++ b/ToDoAppEx.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		478C4E3C29444CF900088126 /* Info.swift in Sources */ = {isa = PBXBuildFile; fileRef = 478C4E3B29444CF900088126 /* Info.swift */; };
 		47C91966293262930009F2F7 /* LoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C91965293262930009F2F7 /* LoginModel.swift */; };
 		47C91968293304A70009F2F7 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C91967293304A70009F2F7 /* LoginViewModel.swift */; };
 		84342FDA46B03BB410F7DD02 /* Pods_ToDoAppEx.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09C99418B6C2D6AACD60CB37 /* Pods_ToDoAppEx.framework */; };
@@ -72,6 +73,7 @@
 /* Begin PBXFileReference section */
 		09C99418B6C2D6AACD60CB37 /* Pods_ToDoAppEx.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ToDoAppEx.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E8C201AAE2FAC4C3E510521 /* Pods-ToDoAppEx-ToDoAppExUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ToDoAppEx-ToDoAppExUITests.debug.xcconfig"; path = "Target Support Files/Pods-ToDoAppEx-ToDoAppExUITests/Pods-ToDoAppEx-ToDoAppExUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		478C4E3B29444CF900088126 /* Info.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Info.swift; sourceTree = "<group>"; };
 		47C91965293262930009F2F7 /* LoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginModel.swift; sourceTree = "<group>"; };
 		47C91967293304A70009F2F7 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		9F33584828AA406F003A5263 /* ImageCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ImageCell.xib; sourceTree = "<group>"; };
@@ -155,6 +157,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		479D549329738E4500CF8BD3 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				478C4E3B29444CF900088126 /* Info.swift */,
+			);
+			path = API;
+			sourceTree = "<group>";
+		};
 		48E14F738DF37A041F75332F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -181,8 +191,9 @@
 		9F5F49912605826E000C2E0A /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				9F5F499226058303000C2E0A /* TodoItem.swift */,
+				479D549329738E4500CF8BD3 /* API */,
 				F44C387D26A67C8400D41ED7 /* User.swift */,
+				9F5F499226058303000C2E0A /* TodoItem.swift */,
 				9FB3A5A0290D54A200B4B849 /* SignUpModel.swift */,
 				47C91965293262930009F2F7 /* LoginModel.swift */,
 			);
@@ -575,6 +586,7 @@
 				9F9647E128756EF100B7244E /* String+Extension.swift in Sources */,
 				F4E7B07428D5BDAD008E0A92 /* SettingCell.swift in Sources */,
 				F44C387E26A67C8400D41ED7 /* User.swift in Sources */,
+				478C4E3C29444CF900088126 /* Info.swift in Sources */,
 				F48F3ADA25F3D8E8001E5342 /* HomeViewController.swift in Sources */,
 				F48F3AD625F3D8E8001E5342 /* AppDelegate.swift in Sources */,
 				9F5F499326058303000C2E0A /* TodoItem.swift in Sources */,

--- a/ToDoAppEx/Base.lproj/Main.storyboard
+++ b/ToDoAppEx/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xix-qy-TEu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xix-qy-TEu">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -534,8 +534,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ugS-BA-zlp">
-                                <rect key="frame" x="20" y="87" width="350" height="558.33333333333337"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ugS-BA-zlp">
+                                <rect key="frame" x="20" y="87" width="350" height="580"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo-1" translatesAutoresizingMaskIntoConstraints="NO" id="O9S-Vq-Vg9">
                                         <rect key="frame" x="0.0" y="0.0" width="350" height="280"/>
@@ -544,7 +544,7 @@
                                         </constraints>
                                     </imageView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="ROt-Mn-NcU">
-                                        <rect key="frame" x="0.0" y="300" width="350" height="258.33333333333326"/>
+                                        <rect key="frame" x="0.0" y="300" width="350" height="280"/>
                                         <subviews>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="cbG-dF-1Pm">
                                                 <rect key="frame" x="0.0" y="0.0" width="350" height="34"/>
@@ -552,26 +552,37 @@
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LzK-rm-X9x">
-                                                <rect key="frame" x="0.0" y="74" width="350" height="34"/>
+                                                <rect key="frame" x="0.0" y="79.666666666666686" width="350" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                                             </textField>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DoY-d5-935">
-                                                <rect key="frame" x="0.0" y="148.33333333333337" width="350" height="40"/>
-                                                <color key="backgroundColor" systemColor="systemGreenColor"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="rKF-Hw-AYv"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
-                                                <state key="normal" title="Login">
-                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                </state>
-                                                <connections>
-                                                    <action selector="login:" destination="4Io-LV-vV1" eventType="touchUpInside" id="p7j-ar-9cW"/>
-                                                </connections>
-                                            </button>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="KcI-Ql-BCr">
+                                                <rect key="frame" x="0.0" y="159.33333333333337" width="350" height="45"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mRV-hK-4hD">
+                                                        <rect key="frame" x="0.0" y="0.0" width="350" height="0.0"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DoY-d5-935">
+                                                        <rect key="frame" x="0.0" y="5" width="350" height="40"/>
+                                                        <color key="backgroundColor" systemColor="systemGreenColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="40" id="rKF-Hw-AYv"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
+                                                        <state key="normal" title="Login">
+                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </state>
+                                                        <connections>
+                                                            <action selector="login:" destination="4Io-LV-vV1" eventType="touchUpInside" id="p7j-ar-9cW"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                            </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aSn-E7-RZ3">
-                                                <rect key="frame" x="0.0" y="228.33333333333337" width="350" height="30"/>
+                                                <rect key="frame" x="0.0" y="250" width="350" height="30"/>
                                                 <state key="normal" title="create account"/>
                                                 <connections>
                                                     <action selector="tappedCreateAccountButton:" destination="4Io-LV-vV1" eventType="touchUpInside" id="Igy-hY-CGz"/>
@@ -593,7 +604,9 @@
                     </view>
                     <connections>
                         <outlet property="email" destination="cbG-dF-1Pm" id="frR-zg-FL5"/>
+                        <outlet property="loginButton" destination="DoY-d5-935" id="bGk-ph-lY8"/>
                         <outlet property="password" destination="LzK-rm-X9x" id="81e-vp-8kf"/>
+                        <outlet property="validationCheckLabel" destination="mRV-hK-4hD" id="Swm-U7-xP4"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="QAv-tR-CZb" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/ToDoAppEx/Model/API/Info.swift
+++ b/ToDoAppEx/Model/API/Info.swift
@@ -1,0 +1,20 @@
+//
+//  Info.swift
+//  ToDoAppEx
+//
+//  Created by 今村京平 on 2022/12/10.
+//
+
+import Foundation
+
+struct Info: Decodable {
+    let isSuccessLogin: Bool
+    let docs: [TodoItem]?
+    let user: User?
+
+    enum CodingKeys: String, CodingKey {
+        case isSuccessLogin = "login"
+        case docs = "docs"
+        case user = "account"
+    }
+}

--- a/ToDoAppEx/Model/LoginModel.swift
+++ b/ToDoAppEx/Model/LoginModel.swift
@@ -1,0 +1,134 @@
+//
+//  LoginModel.swift
+//  ToDoAppEx
+//
+//  Created by 今村京平 on 2022/11/27.
+//
+
+import Foundation
+import RealmSwift
+
+enum LoginModelError: Error {
+    case emptyField
+    case invalidMailAddress
+    case serverError
+    case loginFailure
+    case jsonDecord
+}
+
+protocol LoginModelProtocol {
+    func validate(email: String?, password: String?) -> Result<Void>
+    func login(email: String?, password: String?, completion: @escaping (Result<Void>) -> Void)
+}
+
+final class LoginModel: LoginModelProtocol {
+    private let userDefaults = UserDefaults()
+
+    func validate(email: String?, password: String?) -> Result<Void> {
+        guard let email = email, let password = password else {
+            return .failure(LoginModelError.emptyField)
+        }
+
+        // いずれかの入力がない場合は全て.emptyFieldを返す
+        guard !email.isEmpty, !password.isEmpty else {
+            return .failure(LoginModelError.emptyField)
+        }
+
+        if !email.contains("@") {
+            return .failure(LoginModelError.invalidMailAddress)
+        } else {
+            return .success(())
+        }
+    }
+
+    /// ログインをサーバーに要求
+    /// - Parameters:
+    ///   - email: メールアドレス
+    ///   - password: アカウントのパスワード
+    ///   - completion: ログイン完了後に呼び出されるコールバック
+    func login(email: String?, password: String?, completion: @escaping (Result<Void>) -> Void) {
+        guard let email = email, let password = password else {
+            // ログインボタン押下時にいずれかがnullの場合は実装の仕様違い
+            fatalError()
+        }
+
+        let serverRequest: ServerRequest = ServerRequest()
+        serverRequest.sendServerRequest(
+            urlString: "http://tk2-235-27465.vs.sakura.ne.jp/login",
+            params: [
+                "email": email,
+                "password": password
+            ]) { [weak self] data in
+                guard let data = data else {
+                    print("server error")
+                    completion(.failure(LoginModelError.serverError))
+                    return
+                }
+                do {
+                    // dataをJSONパースし、変数"getJson"に格納
+                    let json = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments)
+                    guard let login : Bool = (json as? NSDictionary)?["login"] as? Bool else {
+                        completion(.failure(LoginModelError.jsonDecord))
+                        return
+                    }
+                    if login {
+                        guard let docs = (json as? NSDictionary)?["docs"] as? NSArray,
+                              let account_scope = (json as? NSDictionary)?["account"] as? NSDictionary else {
+                            completion(.failure(LoginModelError.jsonDecord))
+                            return
+                        }
+                        self?.userDefaults.set(true, forKey: "login")
+                        self?.writeUserInfo(account_scope: account_scope)
+                        self?.writeTodoItem(docs: docs)
+                        completion(.success(()))
+                    } else {
+                        completion(.failure(LoginModelError.loginFailure))
+                    }
+                } catch {
+                    print("json decord error")
+                    completion(.failure(LoginModelError.jsonDecord))
+                    return
+                }
+            }
+    }
+
+    private func writeUserInfo(account_scope: NSDictionary) {
+        let user = User()
+        user.userid = account_scope["_id"] as! String
+        user.accountname = account_scope["accountname"] as! String
+        user.password = account_scope["password"] as! String
+        user.email = account_scope["email"] as! String
+
+        RealmManager.shared.writeItem(user)
+    }
+
+    private func writeTodoItem(docs: NSArray) {
+        let todoItems: Results<TodoItem> = RealmManager.shared.getItemInRealm(type: TodoItem.self)
+
+        for doc in docs {
+            guard let doc = doc as? NSDictionary else { return }
+            let item = TodoItem()
+            item.itemid = doc["itemid"] as! String
+            print(item.itemid)
+            item.accountname = doc["accountname"] as! String
+            item.userid = doc["userid"] as! String
+
+            var existFlag = false
+            for todoitem in todoItems {
+                if todoitem.itemid == item.itemid && todoitem.accountname == item.accountname {
+                    existFlag = true
+                    break
+                }
+            }
+
+            if !existFlag {
+                item.category = doc["category"] as! String
+                item.image = doc["image"] as! String
+                item.title = doc["title"] as! String
+                item.startdate = doc["startdate"] as! String
+                item.enddate = doc["enddate"] as! String
+                RealmManager.shared.writeItem(item)
+            }
+        }
+    }
+}

--- a/ToDoAppEx/Model/LoginModel.swift
+++ b/ToDoAppEx/Model/LoginModel.swift
@@ -67,11 +67,11 @@ final class LoginModel: LoginModelProtocol {
                 do {
                     // dataをJSONパースし、変数"getJson"に格納
                     let json = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments)
-                    guard let login : Bool = (json as? NSDictionary)?["login"] as? Bool else {
+                    guard let isSuccessLogin : Bool = (json as? NSDictionary)?["login"] as? Bool else {
                         completion(.failure(LoginModelError.jsonDecord))
                         return
                     }
-                    if login {
+                    if isSuccessLogin {
                         guard let docs = (json as? NSDictionary)?["docs"] as? NSArray,
                               let account_scope = (json as? NSDictionary)?["account"] as? NSDictionary else {
                             completion(.failure(LoginModelError.jsonDecord))

--- a/ToDoAppEx/Model/TodoItem.swift
+++ b/ToDoAppEx/Model/TodoItem.swift
@@ -8,7 +8,7 @@
 import Foundation
 import RealmSwift
 
-class TodoItem: Object {
+class TodoItem: Object, Decodable {
     @objc dynamic var itemid = ""
     @objc dynamic var accountname = ""
     @objc dynamic var userid = ""
@@ -20,5 +20,17 @@ class TodoItem: Object {
     @objc dynamic var status = false
     override static func primaryKey() -> String? {
         return "itemid"
+    }
+
+    enum CogingKeys: String, CodingKey {
+        case itemid
+        case accountname
+        case userid
+        case title
+        case image
+        case category
+        case startdate
+        case enddate
+        case status
     }
 }

--- a/ToDoAppEx/Model/User.swift
+++ b/ToDoAppEx/Model/User.swift
@@ -8,13 +8,22 @@
 import Foundation
 import RealmSwift
 
-class User: Object {
+class User: Object, Decodable {
     @objc dynamic var userid = ""
     @objc dynamic var accountname = ""
     @objc dynamic var password = ""
     @objc dynamic var email = ""
     @objc dynamic var publicprivate = false
     @objc dynamic var sharepassword = ""
+
+    enum CodingKeys: String, CodingKey {
+        case userid = "_id"
+        case accountname
+        case password
+        case email
+        case publicprivate
+        case sharepassword
+    }
 //    override static func primaryKey() -> String? {
 //        return "userid"
 //    }

--- a/ToDoAppEx/ViewController/LoginViewController.swift
+++ b/ToDoAppEx/ViewController/LoginViewController.swift
@@ -9,92 +9,103 @@ import UIKit
 import RealmSwift
 
 class LoginViewController: UIViewController {
-    @IBOutlet weak var email: UITextField!
-    @IBOutlet weak var password: UITextField!
+    @IBOutlet private weak var email: UITextField!
+    @IBOutlet private weak var password: UITextField!
+    @IBOutlet private weak var validationCheckLabel: UILabel!
+    @IBOutlet private weak var loginButton: UIButton!
 
-    let userDefaults = UserDefaults()
+    private let notificationCenter = NotificationCenter()
+    private lazy var viewModel = LoginViewModel(notificationCenter: notificationCenter)
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // 初期状態でLoginボタンは非活性でグレーにしておく
+        loginButton.isEnabled = false
+        loginButton.backgroundColor = .gray
+
+        setUpBinding()
+    }
     @IBAction private func login(_ sender: Any) {
-        let serverRequest: ServerRequest = ServerRequest()
-        serverRequest.sendServerRequest(
-            urlString: "http://tk2-235-27465.vs.sakura.ne.jp/login",
-            params: [
-                "email": self.email.text ?? "",
-                "password": self.password.text ?? ""
-            ],
-            completion: self.writeModelAndGoToNext(data:))
+        viewModel.login(email: email.text, password: password.text)
     }
 
-    @IBAction func tappedCreateAccountButton(_ sender: Any) {
+    @IBAction private func tappedCreateAccountButton(_ sender: Any) {
         self.dismiss(animated: true)
-    }
-
-    private func writeModelAndGoToNext(data: Data?) {
-        do {
-            var account_scope: NSDictionary?
-            var docs: NSArray?
-            // dataをJSONパースし、変数"getJson"に格納
-            let json = try JSONSerialization.jsonObject(with: data!, options: JSONSerialization.ReadingOptions.allowFragments)
-            let login : Bool = (json as! NSDictionary)["login"] as! Bool
-            if login {
-                docs = (json as! NSDictionary)["docs"] as? NSArray
-                account_scope = (json as! NSDictionary)["account"] as? NSDictionary
-                
-                self.userDefaults.set(true, forKey: "login")
-            } else {
-                self.email.text = "error!!"
-            }
-            let realm = try! Realm()
-            let user = User()
-            user.userid = account_scope!["_id"] as! String
-            user.accountname = account_scope!["accountname"] as! String
-            user.password = account_scope!["password"] as! String
-            user.email = account_scope!["email"] as! String
-            try realm.write {
-                realm.add(user)
-            }
-
-            let todoItems: Results<TodoItem> = realm.objects(TodoItem.self)
-
-            for doc in docs! {
-                let item = TodoItem()
-                item.itemid = (doc as! NSDictionary)["itemid"] as! String
-                print(item.itemid)
-                item.accountname = (doc as! NSDictionary)["accountname"] as! String
-                item.userid = (doc as! NSDictionary)["userid"] as! String
-
-                var existFlag = false
-                for todoitem in todoItems {
-                    if todoitem.itemid == item.itemid && todoitem.accountname == item.accountname {
-                        existFlag = true
-                        break
-                    }
-                }
-
-                if !existFlag {
-                    item.category = (doc as! NSDictionary)["category"] as! String
-                    item.image = (doc as! NSDictionary)["image"] as! String
-                    item.title = (doc as! NSDictionary)["title"] as! String
-                    item.startdate = (doc as! NSDictionary)["startdate"] as! String
-                    item.enddate = (doc as! NSDictionary)["enddate"] as! String
-                    try! realm.write {
-                        realm.add(item)
-                    }
-                }
-            }
-            DispatchQueue.main.async {
-                let secondViewController = self.storyboard?.instantiateViewController(withIdentifier: "TabBarController") as! TabBarController
-                secondViewController.modalPresentationStyle = .fullScreen
-                self.present(secondViewController, animated: false, completion: nil)
-
-            }
-        } catch {
-            print ("json error")
-            return
-        }
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         self.view.endEditing(true)
+    }
+}
+
+// MARK: - private method
+
+extension LoginViewController {
+    private func setUpBinding() {
+        [email, password].forEach { $0?.addTarget(
+            self,
+            action: #selector(textFieldEditingChanged),
+            for: .editingChanged)
+        }
+
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(updateValidationText),
+            name: viewModel.changeText,
+            object: nil)
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(updateIsActivateButton),
+            name: viewModel.activateButton,
+            object: nil)
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(updateValidationColor),
+            name: viewModel.changeColor,
+            object: nil)
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(goToNext),
+            name: viewModel.login,
+            object: nil)
+    }
+}
+
+// MARK: - ViewModel Binding
+
+extension LoginViewController {
+    @objc func textFieldEditingChanged(sender: UITextField) {
+        viewModel.textFieldChange(email: email.text, password: password.text)
+    }
+
+    @objc func updateIsActivateButton(notification: Notification) {
+        guard let isActive = notification.object as? Bool else { return }
+
+        loginButton.isEnabled = isActive
+        loginButton.backgroundColor = isActive ? .systemGreen : .gray
+    }
+
+    @objc func updateValidationText(notification: Notification) {
+        guard let text = notification.object as? String else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.validationCheckLabel.text = text
+        }
+    }
+
+    @objc func updateValidationColor(notification: Notification) {
+        guard let color = notification.object as? UIColor else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.validationCheckLabel.textColor = color
+        }
+    }
+
+    @objc func goToNext() {
+        DispatchQueue.main.async { [weak self] in
+            guard let secondViewController = self?.storyboard?.instantiateViewController(withIdentifier: "TabBarController") as? TabBarController else {
+                return
+            }
+            secondViewController.modalPresentationStyle = .fullScreen
+            self?.present(secondViewController, animated: false, completion: nil)
+        }
     }
 }

--- a/ToDoAppEx/ViewModel/LoginViewModel.swift
+++ b/ToDoAppEx/ViewModel/LoginViewModel.swift
@@ -1,0 +1,73 @@
+//
+//  LoginViewModel.swift
+//  ToDoAppEx
+//
+//  Created by 今村京平 on 2022/11/27.
+//
+
+import Foundation
+import UIKit
+
+final class LoginViewModel {
+    let changeText = Notification.Name("changeLoginText")
+    let changeColor = Notification.Name("changeLoginColor")
+    let activateButton = Notification.Name("activateLoginButton")
+    let login = Notification.Name("login")
+
+    private let notificationCenter: NotificationCenter
+    private let model: LoginModelProtocol
+
+    init(notificationCenter: NotificationCenter, model: LoginModelProtocol = LoginModel()) {
+        self.notificationCenter = notificationCenter
+        self.model = model
+    }
+
+    func textFieldChange(email: String?, password: String?) {
+        let result = model.validate(email: email, password: password)
+
+        switch result {
+        case .success:
+            notificationCenter.post(name: changeText, object: "OK!!!")
+            notificationCenter.post(name: changeColor, object: UIColor.green)
+            notificationCenter.post(name: activateButton, object: true)
+        case .failure(let error as LoginModelError):
+            notificationCenter.post(name: changeText, object: error.errorText)
+            notificationCenter.post(name: changeColor, object: UIColor.red)
+            notificationCenter.post(name: activateButton, object: false)
+        case .failure(_):
+            fatalError("Unexpected pattern.")
+        }
+    }
+
+    func login(email: String?, password: String?) {
+        model.login(email: email, password: password) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success():
+                self.notificationCenter.post(name: self.login, object: nil)
+            case .failure(let error as LoginModelError):
+                self.notificationCenter.post(name: self.changeText, object: error.errorText)
+                self.notificationCenter.post(name: self.changeColor, object: UIColor.red)
+            case .failure(_):
+                fatalError("Unexpected pattern.")
+            }
+        }
+    }
+}
+
+extension LoginModelError {
+    fileprivate var errorText: String {
+        switch self {
+        case .emptyField:
+            return "未入力の項目があります。"
+        case .invalidMailAddress:
+            return "有効でないメールアドレスです。"
+        case .serverError:
+            return "通信でエラーが発生しました。通信環境をお確かめください。"
+        case .loginFailure:
+            return "ログインに失敗しました。メールアドレスとパスワードが正しいかお確かめください。"
+        case .jsonDecord:
+            return "処置中に問題が発生しました。"
+        }
+    }
+}


### PR DESCRIPTION
## 変更点
- ログイン画面に対してMVVMを適用する
- NotificationCenterで
- 実装
  1. LoginModleの追加
  2. LoginViewModelの追加
  3. ViewとViewModelの結合

## どうやって使うか

## なぜ変更/追加したか
- チームメンバーのMVVMへの理解を深めるため
- メンバーが今後増えていった時に設計がきっちりとしている方がタスクが割り振りやすい

## スクショ(UI変更がある場合)
https://user-images.githubusercontent.com/82946608/204123665-fae8e281-5e8a-4c48-9b5f-e3f154cedf3f.mov



## 備考
- 仕様の理解がまだ完全にできてないと思うので、問題ないか確認していただきたいです。（特に、LoginModelのlogin(email:, password:)はログイン成功時のみにRealmにデータを保存するよう変えたのですが、仕様的にあってますでしょうか？
- ログイン失敗時のメッセージを「ログインに失敗しました。メールアドレスとパスワードが正しいかお確かめください。」にしたのですが、大丈夫でしょうか？
- LoginViewControllerのバインディングしている箇所でDispatchQueue.main.async を使っているのですが、こちら実行時に「mainスレッドで実行してください」的なエラーが発生し、クラッシュしたため追加しました。
- Login画面のレイアウトを修正（バリデートラベルの追加）しています。もっとこうしてほしい等ありましたらご指摘いただきたいです。

Closes #56 